### PR TITLE
Fixed the alignment of prop description section

### DIFF
--- a/src/components/ButtonDetailsPage.tsx
+++ b/src/components/ButtonDetailsPage.tsx
@@ -93,6 +93,7 @@ function Example() {
 
         <div className={`${getGlassyClasses()} p-8 mb-8`}>
           <h2 className="text-3xl font-bold mb-6 text-gray-800">Props</h2>
+          <div className="overflow-x-auto">
           <table className="w-full">
             <thead>
               <tr className="border-b border-gray-400">
@@ -123,6 +124,7 @@ function Example() {
               </tr>
             </tbody>
           </table>
+          </div>
         </div>
 
         <div className={`${getGlassyClasses()} p-8 mb-8`}>

--- a/src/components/CardDetailsPage.tsx
+++ b/src/components/CardDetailsPage.tsx
@@ -161,6 +161,7 @@ function Example() {
       <section className="mb-12">
         <h2 className="text-2xl font-bold mb-4 text-gray-800">Props</h2>
         <div className="bg-white bg-opacity-30 backdrop-filter backdrop-blur-md border border-white border-opacity-20 rounded-lg p-6">
+          <div className='overflow-x-auto'>
           <table className="w-full">
             <thead>
               <tr>
@@ -191,6 +192,7 @@ function Example() {
               </tr>
             </tbody>
           </table>
+          </div>
         </div>
       </section>
 

--- a/src/components/ProgressBarDetailPage.tsx
+++ b/src/components/ProgressBarDetailPage.tsx
@@ -139,6 +139,7 @@ function App() {
       {/* Props */}
       <div className={`${getGlassyClasses()} p-6 mb-8`}>
         <h2 className="text-2xl font-bold mb-4 text-gray-800">Props</h2>
+        <div className='overflow-x-auto'>
         <table className="w-full">
           <thead>
             <tr>
@@ -175,6 +176,7 @@ function App() {
             </tr>
           </tbody>
         </table>
+        </div>
       </div>
 
       {/* Custom ProgressBar */}

--- a/src/components/SpeedDialDetailsPage.tsx
+++ b/src/components/SpeedDialDetailsPage.tsx
@@ -194,6 +194,7 @@ const SpeedDialDetailsPage: React.FC = () => {
 
         <div className={`${getGlassyClasses()} p-8 mb-8`}>
           <h2 className="text-3xl font-bold mb-6 text-gray-800">Props</h2>
+          <div className="overflow-x-auto">
           <table className="w-full">
             <thead>
               <tr className="border-b border-gray-400">
@@ -224,6 +225,7 @@ const SpeedDialDetailsPage: React.FC = () => {
               </tr>
             </tbody>
           </table>
+          </div>
         </div>
 
         <div className={`${getGlassyClasses()} p-8 mb-8 relative`}>

--- a/src/components/TooltipDetailsPage.tsx
+++ b/src/components/TooltipDetailsPage.tsx
@@ -98,6 +98,7 @@ function Example() {
         {/* Props table section */}
         <div className={`${getGlassyClasses()} p-8 mb-8`}>
           <h2 className="text-3xl font-bold mb-6 text-gray-800">Props</h2>
+          <div className='overflow-x-auto'>
           <table className="w-full">
             <thead>
               <tr className="border-b border-gray-400">
@@ -122,6 +123,7 @@ function Example() {
               </tr>
             </tbody>
           </table>
+          </div>
         </div>
 
         {/* Tooltip positions section */}


### PR DESCRIPTION
Hi! @Jaishree2310 
I have fixed the alignment of the prop description section #31 
Here is the screenshot of updated version
![Screenshot_2024_1006_223128](https://github.com/user-attachments/assets/3b346c2e-c525-414b-9909-e11d1ba3155c)

Also please assign a level label 