### PR TITLE
Fixes #30 Button Text Color Changes on Different Pages

### DIFF
--- a/src/components/TextareaDetailPage.tsx
+++ b/src/components/TextareaDetailPage.tsx
@@ -142,7 +142,7 @@ const TextareaDetailPage: React.FC = () => {
       </div>
 
       <div className="relative z-10 text-black">
-        <button 
+        <button style={{color:'black'}}
           onClick={() => navigate(-1)} 
           className={`mb-8 flex items-center ${getGlassyClasses()} px-4 py-2 hover:bg-opacity-20 text-black transition-all duration-300`}
         >


### PR DESCRIPTION
## Fixes issue #30 
 The "Back to Components" button isn't staying consistent with its text color  across all page specially in the Text area detail page it is turning into white
so,i have add the inline style  in back to component button - color:black this fix the issue and the button text color is now consistent across all the pages