### PR TITLE
Fixes #46: Added Animation on the main page card Element

### DIFF
--- a/src/components/GlassyUILandingPage.tsx
+++ b/src/components/GlassyUILandingPage.tsx
@@ -33,7 +33,7 @@ const GlassyUILandingPage: React.FC = () => {
           </a>
         </header>
 
-        <main className="text-center p-8 rounded-xl backdrop-filter backdrop-blur-lg bg-white bg-opacity-10 shadow-lg border border-white border-opacity-20 relative transition-all duration-300 ease-in-out hover:scale-105 hover:shadow-2xl hover:bg-opacity-20">
+        <main className="fade-in text-center p-8 rounded-xl backdrop-filter backdrop-blur-lg bg-white bg-opacity-10 shadow-lg border border-white border-opacity-20 relative transition-all duration-300 ease-in-out hover:scale-105 hover:shadow-2xl hover:bg-opacity-20">
 
           <h1 className="text-6xl font-bold mb-2 text-white">Glassy UI</h1>
           <p className="text-xl mb-6 text-white">A sleek glassmorphism UI library.</p>

--- a/src/index.css
+++ b/src/index.css
@@ -23,7 +23,26 @@ code {
   border: 1px solid rgba(255, 255, 255, 0.18);
   box-shadow: 0 8px 32px 0 rgba(31, 38, 135, 0.37);
 }
+/* Fade In Effect */
+@keyframes fade {
+  from{
+    transform: translateY(50px);
+    opacity: 0;
+  }
+}
 
+.fade-in{
+  animation: fade 350ms ease-out;
+}
+
+@keyframes shine {
+  0% {
+    transform: translateX(-100%) translateY(-100%) rotate(45deg);
+  }
+  100% {
+    transform: translateX(100%) translateY(100%) rotate(45deg);
+  }
+}
 @keyframes shine {
   0% {
     transform: translateX(-100%) translateY(-100%) rotate(45deg);

--- a/src/index.css
+++ b/src/index.css
@@ -43,14 +43,6 @@ code {
     transform: translateX(100%) translateY(100%) rotate(45deg);
   }
 }
-@keyframes shine {
-  0% {
-    transform: translateX(-100%) translateY(-100%) rotate(45deg);
-  }
-  100% {
-    transform: translateX(100%) translateY(100%) rotate(45deg);
-  }
-}
 
 .shine-effect::before {
   content: '';


### PR DESCRIPTION
fixed #46, _adding a smooth animation effect where the card fades in and moves slightly upwards to its intended position._

If you are going to merge it, just make sure to add label (gssoc-ext, hactoberfest and Level1, Level2, Level3).