### PR TITLE
Fixing bottom spacing of Glossy text

### DIFF
--- a/src/components/GlassyUILandingPage.css
+++ b/src/components/GlassyUILandingPage.css
@@ -27,4 +27,5 @@
   text-fill-color: transparent;
   display: inline-block;
   text-shadow: 0px 0px 10px rgba(255, 255, 255, 0.3);
+  padding-bottom: 10px;
 }


### PR DESCRIPTION
### **Fixing the bottom spacing of the Glossy text**

**After:**
![image](https://github.com/user-attachments/assets/adc8f9d0-e676-4aa3-b178-82c5ef5570c6)



**Before:**
![image](https://github.com/user-attachments/assets/a8209e99-72e4-497b-8465-77d205aada0a)
