### PR TITLE
[Stories] Fix: white background and center form on Stories page

### DIFF
--- a/src/components/Stories.tsx
+++ b/src/components/Stories.tsx
@@ -14,7 +14,6 @@ const Stories = () => {
   const [category, setCategory] = useState('');
 
   useEffect(() => {
-    // Fetch posts from the backend API
     const fetchPosts = async () => {
       try {
         const response = await fetch(
@@ -59,7 +58,7 @@ const Stories = () => {
 
         if (response.ok) {
           const savedPost = await response.json();
-          setPosts([savedPost, ...posts]); // Add the new post to state
+          setPosts([savedPost, ...posts]);
         } else {
           console.error('Failed to save the post');
         }
@@ -67,7 +66,6 @@ const Stories = () => {
         console.error('Error saving the post:', error);
       }
 
-      // Clear form fields
       setTitle('');
       setContent('');
       setCategory('');
@@ -75,14 +73,21 @@ const Stories = () => {
   };
 
   return (
-    <>
+    <div className='min-h-screen bg-gradient-to-br from-gray-900 via-gray-800 to-gray-900'>
       <h1 className='text-3xl font-bold text-center mb-5 text-gray-100 mt-20'>
         Real Stories, Real Advice: Share Your Experience
       </h1>
+      {posts.length === 0 && (
+        <p className='text-gray-400 text-center mb-6'>
+          No posts yet. Share your experience!
+        </p>
+      )}
 
-      <div className='flex flex-col lg:flex-row items-start gap-8 px-6 lg:px-20 mb-14'>
+      <div className='flex flex-col lg:flex-row items-start justify-center gap-8 px-6 lg:px-20 mb-14'>
         {/* Left side - Posts */}
-        <div className='flex-1 space-y-6'>
+        <div
+          className={`space-y-6 ${posts.length === 0 ? 'hidden' : 'flex-1'}`}
+        >
           {posts.length === 0 ? (
             <p className='text-gray-400 text-center'>
               No posts yet. Share your experience!
@@ -116,7 +121,7 @@ const Stories = () => {
         </div>
 
         {/* Right side - Form */}
-        <div className='w-full lg:w-1/3 bg-gray-800 p-6 rounded-lg shadow-md'>
+        <div className='w-full lg:w-2/5 bg-gray-800 p-6 rounded-lg shadow-md'>
           <form className='space-y-4'>
             <input
               type='text'
@@ -139,7 +144,6 @@ const Stories = () => {
               <option value='' disabled>
                 Select Category
               </option>
-
               <optgroup label='GlassyUI-Components'>
                 <option value='GlassyUI Introduction'>
                   GlassyUI Introduction
@@ -175,7 +179,7 @@ const Stories = () => {
           </form>
         </div>
       </div>
-    </>
+    </div>
   );
 };
 


### PR DESCRIPTION
This PR fixes the Stories page which had a plain white background instead of the dark glassmorphism theme used across the rest of the site. The form was also misaligned to the right when no posts exist.

**Changes made:**
- Wrapped the return in a div with dark gradient background (bg-gradient-to-br from-gray-900 via-gray-800 to-gray-900)
- Fixed form centering when no posts exist by hiding the empty left div instead of letting it push the form to the right

**Notes for Reviewers**
The bug was caused by the component returning a fragment (<>) with no background styling. The fix matches the existing dark theme used on all other pages. No other components were affected.

<img width="1416" height="780" alt="Screenshot 2026-05-11 at 1 53 58 PM" src="https://github.com/user-attachments/assets/ea136398-d017-4d92-94b4-4703acdc5beb" />
