### PR TITLE
UI Bug: Back to Components button overlaps with navbar on toast page

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -131,7 +131,7 @@ const Header: React.FC = () => {
 
 const navStyle: React.CSSProperties = {
   padding: '10px',
-  position: 'fixed',
+  position: 'sticky',
   top: '0',
   width: '100%',
   zIndex: 1000,


### PR DESCRIPTION
Description

This PR fixes the UI overlap issue on the Toast Page where the “Back to Components” button was overlapping with the navbar/logo section.

Fixes #522 

Changes Made

* Added proper top spacing below the navbar
* Adjusted layout alignment for the back button section
* Improved overall UI consistency on the toast page

Notes for Reviewers

* Verified the fix locally
* The overlap issue no longer appears on different screen sizes


<img width="1470" height="956" alt="Screenshot 2026-05-16 at 18 05 36" src="https://github.com/user-attachments/assets/1c91cd27-b3e8-4f2f-8c6d-65baf74d278f" />



**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits


By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
