### PR TITLE
fix: restore scroll position on route transitions (resolves #457)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,6 +9,7 @@ import {
 } from 'react-router-dom';
 
 import ScrollProgressBar from './components/ScrollProgress'; // Import your ScrollProgressBar component
+import ScrollToTop from './components/ScrollToTop';
 import GlassyUILandingPage from './components/GlassyUILandingPage';
 import GlassyUIComponentsPage from './components/GlassyUIComponentsPage';
 import ButtonDetailsPage from './components/ButtonDetailsPage';
@@ -80,6 +81,7 @@ const ThemeToggle: React.FC = () => {
 const App: React.FC = () => {
   return (
     <Router>
+      <ScrollToTop />
       <Header />
       <AiChatbot />
       {/* <ThemeToggle /> */}

--- a/src/components/ScrollToTop.tsx
+++ b/src/components/ScrollToTop.tsx
@@ -1,0 +1,14 @@
+import { useEffect } from 'react';
+import { useLocation } from 'react-router-dom';
+
+const ScrollToTop: React.FC = () => {
+  const { pathname } = useLocation();
+
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, [pathname]);
+
+  return null;
+};
+
+export default ScrollToTop;


### PR DESCRIPTION
### Description
This pull request resolves a jarring user experience bug where navigating between routes in the Single Page Application (SPA) would persist the window scroll position. Specifically, clicking on category items like the "Cards" ComponentCard from down the `/components` page redirected the user to details views that opened scrolled to the bottom (showing the footer) instead of loading clean from the top.

### Root Cause
Because client-side routing in `react-router-dom` updates the DOM dynamically without initiating a standard browser page reload, the window's viewport scroll coordinates are not reset by default. Currently, there was no centralized navigation event listener to handle scroll restoration.

### Solution & Changes
1. **Created `ScrollToTop.tsx` Component**: Implemented a lightweight, non-rendering React component utilizing the standard `useLocation` hook inside a React `useEffect` callback to trigger `window.scrollTo(0, 0)` synchronously on route changes.
2. **Integrated in `App.tsx`**: Mounted the new `<ScrollToTop />` component within the core `<Router>` element, registering scroll restoration globally across the application.

### Verification & Proofs
Tested locally at `http://localhost:3000` to confirm that all route transitions (including long category listings) cleanly and smoothly load starting at `(0, 0)` from the top.

Fixes #457
