### PR TITLE
fix: resolve back to components button overlap on slider details page

### DIFF
--- a/src/components/SliderDetailsPage.tsx
+++ b/src/components/SliderDetailsPage.tsx
@@ -68,7 +68,7 @@ const SliderDetailsPage: React.FC = () => {
   return (
     <div className='min-h-screen p-8 font-sans bg-gradient-to-r from-gray-800 via-gray-900 to-black text-white relative'>
       <BackToTopButton />
-      <nav className='mb-8 flex items-center justify-between relative z-10'>
+      <nav className='mt-20 mb-8 flex items-center justify-between relative z-10'>
         <button
           onClick={handleBackToComponents}
           className={`flex items-center ${getGlassyClasses()} px-4 py-2 hover:bg-opacity-20 text-white`}


### PR DESCRIPTION
## Description
Resolved overlap issue between navbar and Back to Components button on slider details page.

## Changes Made
- Added top spacing to prevent overlap
- Improved alignment with navbar
- Verified layout visually on localhost

Fixes #522

## Notes for Reviewers
- [x] Yes, I signed my commits.