### PR TITLE
fix: add error handling to unhandled promise rejections (#638)

### DIFF
--- a/src/components/CalendarDetails.tsx
+++ b/src/components/CalendarDetails.tsx
@@ -35,7 +35,7 @@ const CalendarDetail: React.FC = () => {
         () => setCopiedStates(prev => ({ ...prev, [key]: false })),
         2000,
       );
-    });
+    }).catch(err => console.error('Failed to copy:', err));
   };
   const getGlassyClasses = () => {
     return 'bg-white bg-opacity-20 rounded-lg shadow-lg'; // Customize as needed

--- a/src/components/DropdowndetailsPage.tsx
+++ b/src/components/DropdowndetailsPage.tsx
@@ -58,7 +58,7 @@ const DropdownMenuDetailsPage: React.FC = () => {
         () => setCopiedStates(prev => ({ ...prev, [key]: false })),
         2000,
       );
-    });
+    }).catch(err => console.error('Failed to copy:', err));
   };
 
   const CopyButton: React.FC<{ text: string; codeKey: string }> = ({

--- a/src/components/NavigationDetailsPage.tsx
+++ b/src/components/NavigationDetailsPage.tsx
@@ -19,7 +19,7 @@ const NavigationDetailsPage: React.FC = () => {
     navigator.clipboard.writeText(text).then(() => {
       setCopiedText(text);
       setTimeout(() => setCopiedText(null), 2000);
-    });
+    }).catch(err => console.error('Failed to copy:', err));
   };
 
   const CopyButton: React.FC<{ text: string; codeKey: string }> = ({

--- a/src/components/PaginationDetails.tsx
+++ b/src/components/PaginationDetails.tsx
@@ -21,7 +21,7 @@ const PaginationDetails: React.FC = () => {
         () => setCopiedStates(prev => ({ ...prev, [key]: false })),
         2000,
       );
-    });
+    }).catch(err => console.error('Failed to copy:', err));
   };
 
   const CopyButton: React.FC<{ text: string; codeKey: string }> = ({

--- a/src/components/StatisticDetails.tsx
+++ b/src/components/StatisticDetails.tsx
@@ -20,7 +20,7 @@ const StatisticDetails: React.FC = () => {
         () => setCopiedStates(prev => ({ ...prev, [key]: false })),
         2000,
       );
-    });
+    }).catch(err => console.error('Failed to copy:', err));
   };
 
   const CopyButton: React.FC<{ text: string; codeKey: string }> = ({


### PR DESCRIPTION
## Summary\nAdded \.catch()\ handlers to \
avigator.clipboard.writeText()\ promise chains across multiple components to prevent unhandled promise rejections.\n\n## Changes\nAdded \.catch(err => console.error('Failed to copy:', err))\ to clipboard write operations in:\n- \DropdowndetailsPage.tsx\\n- \StatisticDetails.tsx\\n- \CalendarDetails.tsx\\n- \NavigationDetailsPage.tsx\\n- \PaginationDetails.tsx\\n\nFixes #638