### PR TITLE
fix(a11y): add aria-label to interactive buttons (#637)

### DIFF
--- a/src/components/CalendarDetails.tsx
+++ b/src/components/CalendarDetails.tsx
@@ -49,6 +49,7 @@ const CalendarDetail: React.FC = () => {
       onClick={() => copyToClipboard(text, codeKey)}
       className={`absolute top-4 right-4 p-2 bg-white bg-opacity-20 rounded-lg shadow-lg hover:bg-opacity-30`}
       title='Copy to clipboard'
+      aria-label='Copy to clipboard'
     >
       {copiedStates[codeKey] ? <Check size={20} /> : <Copy size={20} />}
     </button>

--- a/src/components/DropdowndetailsPage.tsx
+++ b/src/components/DropdowndetailsPage.tsx
@@ -69,6 +69,7 @@ const DropdownMenuDetailsPage: React.FC = () => {
       onClick={() => copyToClipboard(text, codeKey)}
       className={`absolute top-2 right-2 ${getGlassyClasses()} p-2 hover:bg-white/40 transition-all duration-300 z-10`}
       title='Copy to clipboard'
+      aria-label='Copy to clipboard'
     >
       {copiedStates[codeKey] ? (
         <Check size={16} className='text-green-600' />

--- a/src/components/NavigationDetailsPage.tsx
+++ b/src/components/NavigationDetailsPage.tsx
@@ -30,6 +30,7 @@ const NavigationDetailsPage: React.FC = () => {
       onClick={() => copyToClipboard(text, codeKey)}
       className={`absolute top-2 right-2 ${getGlassyClasses()} p-2 hover:bg-white/40 transition-all duration-300 z-10`}
       title='Copy to clipboard'
+      aria-label='Copy to clipboard'
     >
       {copiedText ? (
         <Check size={16} className='text-green-600' />
@@ -191,6 +192,7 @@ const NavigationDetailsPage: React.FC = () => {
               <button
                 className='md:hidden flex items-center justify-start p-3'
                 onClick={() => setMenuOpen(!menuOpen)}
+                aria-label='Toggle navigation menu'
               >
                 <Menu size={20} className='mr-2' />
               </button>

--- a/src/components/StatisticDetails.tsx
+++ b/src/components/StatisticDetails.tsx
@@ -31,6 +31,7 @@ const StatisticDetails: React.FC = () => {
       onClick={() => copyToClipboard(text, codeKey)}
       className={`absolute top-2 right-2 ${getGlassyClasses()} p-2 hover:bg-white/40 transition-all duration-300 z-10`}
       title='Copy to clipboard'
+      aria-label='Copy to clipboard'
     >
       {copiedStates[codeKey] ? (
         <Check size={16} className='text-green-600' />


### PR DESCRIPTION
﻿## Summary
Added ria-label attributes to icon-only buttons in multiple components to improve screen reader accessibility.

## Changes
- DropdowndetailsPage.tsx: ria-label="Copy to clipboard" on copy button
- StatisticDetails.tsx: ria-label="Copy to clipboard" on copy button
- CalendarDetails.tsx: ria-label="Copy to clipboard" on copy button
- NavigationDetailsPage.tsx: ria-label="Copy to clipboard" on copy button, ria-label="Toggle navigation menu" on hamburger button

Fixes #637
