### PR TITLE
[A11Y] Add missing aria-labels to interactive buttons

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -72,7 +72,7 @@ const ThemeToggle: React.FC = () => {
   };
 
   return (
-    <button
+    <button aria-label="button"
       onClick={toggleTheme}
       className='p-2 bg-gray-200 dark:bg-gray-800 text-black dark:text-white rounded'
     >

--- a/src/components/AIChatbot.tsx
+++ b/src/components/AIChatbot.tsx
@@ -164,7 +164,7 @@ const AiChatbot: React.FC = () => {
                   </p>
                 </div>
               </div>
-              <button
+              <button aria-label="button"
                 onClick={() => setIsOpen(false)}
                 className='p-1.5 rounded-full hover:bg-white/10 transition-colors text-white/70 hover:text-white'
                 aria-label='Close Chat'
@@ -252,7 +252,7 @@ const AiChatbot: React.FC = () => {
       </AnimatePresence>
 
       {/* Floating Toggle Button */}
-      <button
+      <button aria-label="button"
         onClick={() => setIsOpen(!isOpen)}
         className='p-4 rounded-full bg-gradient-to-r from-blue-600 to-purple-600 hover:from-blue-500 hover:to-purple-500 text-white shadow-lg border border-white/20 hover:scale-110 active:scale-95 transition-all duration-300 flex items-center justify-center relative group'
         aria-label='Open Chat'

--- a/src/components/Accordion.tsx
+++ b/src/components/Accordion.tsx
@@ -18,7 +18,7 @@ const Accordion: React.FC<AccordionProps> = ({ title, content }) => {
 
   return (
     <div className={`${getGlassyClasses()} mb-4`}>
-      <button
+      <button aria-label="button"
         onClick={toggleAccordion}
         className='w-full text-left px-4 py-2 focus:outline-none'
       >

--- a/src/components/AccordionDetails.tsx
+++ b/src/components/AccordionDetails.tsx
@@ -22,7 +22,7 @@ const CollapsibleAccordion: React.FC<{
           className='rounded-2xl border border-gray-600 overflow-hidden'
         >
           {/* Accordion Button */}
-          <button
+          <button aria-label="button"
             className={`w-full text-left p-4 transition-all duration-300 ${
               activeIndex === index
                 ? 'bg-white/30 text-white'
@@ -79,7 +79,7 @@ const AccordionDetails: React.FC = () => {
     text,
     codeKey,
   }) => (
-    <button
+    <button aria-label="button"
       onClick={() => copyToClipboard(text, codeKey)}
       className={`absolute top-2 right-2 ${getGlassyClasses()} p-2 hover:bg-white/40 transition-all duration-300 z-10`}
       title='Copy to clipboard'
@@ -121,7 +121,7 @@ const AccordionDetails: React.FC = () => {
     <div className="space-y-4">
       {items.map((item, index) => (
         <div key={index}>
-          <button onClick={() => toggleAccordion(index)}>{item.title}</button>
+          <button aria-label="button" onClick={() => toggleAccordion(index)}>{item.title}</button>
           {activeIndex === index && <div>{item.content}</div>}
         </div>
       ))}
@@ -133,7 +133,7 @@ const AccordionDetails: React.FC = () => {
     <div className='min-h-screen pt-24 px-8 pb-8 font-sans bg-gradient-to-r from-gray-800 via-gray-900 to-black text-white relative'>
       <BackToTopButton />
       <div className='relative z-10'>
-        <button
+        <button aria-label="button"
           onClick={() => navigate(-1)}
           className={`mb-8 flex items-center ${getGlassyClasses(10)} px-4 py-2 hover:bg-white/40 transition-all duration-300 text-white`}
         >

--- a/src/components/AuthenticationCards.tsx
+++ b/src/components/AuthenticationCards.tsx
@@ -69,7 +69,7 @@ const AuthenticationCardDetailsPage: React.FC = () => {
     text,
     codeKey,
   }) => (
-    <button
+    <button aria-label="button"
       onClick={() => copyToClipboard(text, codeKey)}
       className='absolute top-2 right-2 p-1 bg-white bg-opacity-30 backdrop-filter backdrop-blur-md border border-white border-opacity-20 rounded-lg shadow-lg hover:bg-opacity-40 transition-all duration-300'
       title='Copy to clipboard'
@@ -141,7 +141,7 @@ const AuthenticationCardDetailsPage: React.FC = () => {
                 placeholder='Enter your password'
               />
             </div>
-            <button
+            <button aria-label="button"
               type='submit'
               className='w-full bg-blue-500 text-white font-semibold py-2 px-4 rounded-md hover:bg-blue-600 transition duration-200'
             >
@@ -198,7 +198,7 @@ const AuthenticationCardDetailsPage: React.FC = () => {
               placeholder="Enter your password"
             />
           </div>
-          <button
+          <button aria-label="button"
             type="submit"
             className="w-full bg-blue-500 text-white font-semibold py-2 px-4 rounded-md hover:bg-blue-600 transition duration-200"
           >
@@ -269,7 +269,7 @@ const AuthenticationCardDetailsPage: React.FC = () => {
               placeholder='Enter your password'
             />
           </div>
-          <button
+          <button aria-label="button"
             type='submit'
             className='w-full bg-blue-500 text-white font-semibold py-2 px-4 rounded-md hover:bg-blue-600 transition duration-200'
           >
@@ -326,7 +326,7 @@ const AuthenticationCardDetailsPage: React.FC = () => {
               placeholder='Enter your password'
             />
           </div>
-          <button
+          <button aria-label="button"
             type='submit'
             className='w-full bg-blue-500 text-white font-semibold py-2 px-4 rounded-md hover:bg-blue-600 transition duration-200'
           >
@@ -341,7 +341,7 @@ const AuthenticationCardDetailsPage: React.FC = () => {
   return (
     <div className='min-h-screen pt-24 px-8 pb-8 font-sans bg-gradient-to-r from-gray-800 via-gray-900 to-black text-white relative'>
       <BackToTopButton />
-      <button
+      <button aria-label="button"
         onClick={() => navigate(-1)}
         className={`mb-8 flex items-center ${getGlassyClasses(10)} px-4 py-2 hover:bg-opacity-40 transition-all duration-300  text-gray-100`}
       >
@@ -448,7 +448,7 @@ const AuthenticationCardDetailsPage: React.FC = () => {
               placeholder="Enter your password"
             />
           </div>
-          <button
+          <button aria-label="button"
             type="submit"
             className="w-full bg-blue-500 text-white font-semibold py-2 px-4 rounded-md hover:bg-blue-600 transition duration-200"
           >
@@ -504,7 +504,7 @@ const AuthenticationCardDetailsPage: React.FC = () => {
               placeholder="Enter your password"
             />
           </div>
-          <button
+          <button aria-label="button"
             type="submit"
             className="w-full bg-blue-500 text-white font-semibold py-2 px-4 rounded-md hover:bg-blue-600 transition duration-200"
           >
@@ -588,7 +588,7 @@ const AuthenticationCardDetailsPage: React.FC = () => {
               placeholder="Enter your password"
             />
           </div>
-          <button
+          <button aria-label="button"
             type="submit"
             className="w-full bg-blue-500 text-white font-semibold py-2 px-4 rounded-md hover:bg-blue-600 transition duration-200"
           >
@@ -655,7 +655,7 @@ const AuthenticationCardDetailsPage: React.FC = () => {
               placeholder="Enter your password"
             />
           </div>
-          <button
+          <button aria-label="button"
             type="submit"
             className="w-full bg-blue-500 text-white font-semibold py-2 px-4 rounded-md hover:bg-blue-600 transition duration-200"
           >

--- a/src/components/BackToTop.tsx
+++ b/src/components/BackToTop.tsx
@@ -51,7 +51,7 @@ const BackToTopButton: React.FC = () => {
   return (
     <>
       {isVisible && (
-        <button
+        <button aria-label="button"
           onClick={scrollToTop}
           className='z-50 fixed lg:bottom-[90px] lg:right-6 bottom-[168px] right-4 p-4 rounded-full bg-gradient-to-r from-[#8b5cf6] to-[#3b82f6] hover:from-[#7c3aed] hover:to-[#2563eb] text-white shadow-lg border border-white/20 hover:scale-110 active:scale-95 transition-all duration-300 flex items-center justify-center'
           style={isMobile ? { bottom: '168px', right: '16px' } : undefined}

--- a/src/components/BackToTopDetailsPage.tsx
+++ b/src/components/BackToTopDetailsPage.tsx
@@ -28,7 +28,7 @@ const BackToTopDetailsPage: React.FC = () => {
     text,
     codeKey,
   }) => (
-    <button
+    <button aria-label="button"
       onClick={() => copyToClipboard(text, codeKey)}
       className={`absolute top-2 right-2 ${getGlassyClasses()} p-2 hover:bg-white/40 transition-all duration-300 z-10`}
       title='Copy to clipboard'
@@ -52,7 +52,7 @@ const BackToTopDetailsPage: React.FC = () => {
   };
 
   return (
-    <button
+    <button aria-label="button"
       onClick={handleScroll}
       className="fixed bottom-5 right-5 py-3 px-5 bg-blue-500 rounded-full text-white shadow-lg transition-transform hover:scale-105"
       title="Back to Top"
@@ -65,7 +65,7 @@ const BackToTopDetailsPage: React.FC = () => {
   return (
     <div className='min-h-screen pt-24 px-8 pb-8 font-sans bg-gradient-to-r from-gray-800 via-gray-900 to-black text-white relative'>
       <div className='relative z-10'>
-        <button
+        <button aria-label="button"
           onClick={() => navigate(-1)}
           className={`mb-8 flex items-center ${getGlassyClasses(10)} px-4 py-2 hover:bg-white/40 transition-all duration-300 text-gray-300`}
         >
@@ -130,7 +130,7 @@ const BackToTopDetailsPage: React.FC = () => {
             Customize the button's style through the className prop or inline
             styles.
           </p>
-          <button
+          <button aria-label="button"
             className={`fixed bottom-5 right-5 py-3 px-5 bg-blue-500 rounded-full text-white shadow-lg transition-transform hover:scale-105`}
             title='Back to Top'
             onClick={() => window.scrollTo({ top: 0, behavior: 'smooth' })}

--- a/src/components/ButtonDetailsPage.tsx
+++ b/src/components/ButtonDetailsPage.tsx
@@ -33,7 +33,7 @@ const ButtonDetailsPage: React.FC = () => {
     text,
     codeKey,
   }) => (
-    <button
+    <button aria-label="button"
       onClick={() => copyToClipboard(text, codeKey)}
       className={`absolute top-2 right-2 ${getGlassyClasses()} p-2 hover:bg-white/40 transition-all duration-300 z-10`}
       title='Copy to clipboard'
@@ -94,7 +94,7 @@ function Example() {
     <div className='min-h-screen pt-24 px-8 pb-8 font-sans bg-gradient-to-r from-gray-800 via-gray-900 to-black text-white relative'>
       <BackToTopButton />
       <div className='relative z-10'>
-        <button
+        <button aria-label="button"
           onClick={() => navigate(-1)}
           className={`mb-8 flex items-center ${getGlassyClasses(10)} px-4 py-2 hover:bg-white/40 transition-all duration-300 text-white`}
         >
@@ -172,7 +172,7 @@ function Example() {
               </h3>
               <div className='flex space-x-4 mb-4'>
                 {instagramThemes.map((color, index) => (
-                  <button
+                  <button aria-label="button"
                     key={index}
                     className='w-8 h-8 rounded-full border-2 border-white shadow-lg transition-transform hover:scale-110'
                     style={{ backgroundColor: color }}
@@ -265,7 +265,7 @@ function Example() {
             </div>
 
             <div className='relative mt-8'>
-              <button
+              <button aria-label="button"
                 className={`py-3 px-6 text-lg font-semibold rounded-lg ${getGlassyClasses()} hover:bg-white/40 transition-transform hover:scale-110`}
                 style={{
                   backgroundColor: `${customBg}40`,
@@ -288,7 +288,7 @@ function Example() {
           <p className='mb-6 text-lg text-white'>
             A button that triggers an alert message when clicked.
           </p>
-          <button
+          <button aria-label="button"
             onClick={() => alert('Button clicked!')}
             className={`${getGlassyClasses()} px-6 py-3 text-lg font-semibold rounded-lg hover:bg-white/40 transition-transform hover:scale-110 text-white`}
           >
@@ -309,7 +309,7 @@ function Example() {
           <p className='mb-6 text-lg text-white'>
             A button that spans the full width of its container.
           </p>
-          <button
+          <button aria-label="button"
             className={`w-full py-3 text-lg font-semibold rounded-lg ${getGlassyClasses()} hover:bg-white/40 transition-transform hover:scale-105 text-white`}
           >
             Full Width Button

--- a/src/components/CalendarDetails.tsx
+++ b/src/components/CalendarDetails.tsx
@@ -45,7 +45,7 @@ const CalendarDetail: React.FC = () => {
     text,
     codeKey,
   }) => (
-    <button
+    <button aria-label="button"
       onClick={() => copyToClipboard(text, codeKey)}
       className={`absolute top-4 right-4 p-2 bg-white bg-opacity-20 rounded-lg shadow-lg hover:bg-opacity-30`}
       title='Copy to clipboard'
@@ -75,7 +75,7 @@ const CalendarDetail: React.FC = () => {
     <div className='min-h-screen pt-24 px-8 pb-8 font-sans bg-gradient-to-r from-gray-800 via-gray-900 to-black text-white relative flex flex-col '>
       <BackToTopButton />
       <nav className='mb-8 flex items-center justify-between relative z-10'>
-        <button
+        <button aria-label="button"
           onClick={handleBackToComponents}
           className={`flex items-center p-2 bg-white bg-opacity-20 rounded-lg shadow-lg hover:bg-opacity-30`}
         >

--- a/src/components/CardDetailsPage.tsx
+++ b/src/components/CardDetailsPage.tsx
@@ -65,7 +65,7 @@ const CardDetailsPage: React.FC = () => {
     text,
     codeKey,
   }) => (
-    <button
+    <button aria-label="button"
       onClick={() => copyToClipboard(text, codeKey)}
       className='absolute top-2 right-2 p-1 bg-white bg-opacity-30 backdrop-filter backdrop-blur-md border border-white border-opacity-20 rounded-lg shadow-lg hover:bg-opacity-40 transition-all duration-300'
       title='Copy to clipboard'
@@ -174,7 +174,7 @@ const CardDetailsPage: React.FC = () => {
   return (
     <div className='min-h-screen pt-24 px-8 pb-8 font-sans bg-gradient-to-r from-gray-800 via-gray-900 to-black text-white relative'>
       <BackToTopButton />
-      <button
+      <button aria-label="button"
         onClick={() => navigate(-1)}
         className={`mb-8 flex items-center ${getGlassyClasses(10)} px-4 py-2 hover:bg-opacity-20 text-white`}
       >
@@ -273,7 +273,7 @@ function Example() {
           <div className='mb-4 flex items-center'>
             <span className='text-lg font-bold mr-2'>Theme:</span>
             {Object.keys(themes).map(theme => (
-              <button
+              <button aria-label="button"
                 key={theme}
                 onClick={() => setCurrentTheme(theme)}
                 className={`w-6 h-6 rounded-full border-2 mr-2 ${

--- a/src/components/CheckboxDetails.tsx
+++ b/src/components/CheckboxDetails.tsx
@@ -50,7 +50,7 @@ const CheckboxDetailsPage: React.FC = () => {
     text,
     codeKey,
   }) => (
-    <button
+    <button aria-label="button"
       onClick={() => copyToClipboard(text, codeKey)}
       className={`absolute top-2 right-2 ${getGlassyClasses()} p-2 hover:bg-white/40 transition-all duration-300 z-10`}
       title='Copy to clipboard'
@@ -123,7 +123,7 @@ const CheckboxDetailsPage: React.FC = () => {
     <div className='min-h-screen pt-24 px-8 pb-8 font-sans bg-gradient-to-r from-gray-800 via-gray-900 to-black text-white relative'>
       <BackToTopButton />
       <div className='relative z-10'>
-        <button
+        <button aria-label="button"
           onClick={() => navigate(-1)}
           className={`mb-8 flex items-center ${getGlassyClasses(10)} px-4 py-2 hover:bg-white/40 transition-all duration-300 text-white`}
         >

--- a/src/components/ColorPicker.tsx
+++ b/src/components/ColorPicker.tsx
@@ -225,7 +225,7 @@ const ColorPicker: React.FC<ColorPickerProps> = ({
         </label>
       )}
 
-      <button
+      <button aria-label="button"
         ref={triggerRef}
         onClick={() => setOpen(!open)}
         className={`flex items-center gap-3 ${getGlassyClasses(20)} px-2 py-2 hover:bg-opacity-30 active:scale-95 transition-transform`}
@@ -286,7 +286,7 @@ const ColorPicker: React.FC<ColorPickerProps> = ({
                 }}
               />
               {'EyeDropper' in window && (
-                <button
+                <button aria-label="button"
                   onClick={handleEyeDropper}
                   className={`${getGlassyClasses(20)} p-1.5 hover:bg-opacity-30 text-white flex-shrink-0`}
                 >

--- a/src/components/ContactUs.tsx
+++ b/src/components/ContactUs.tsx
@@ -187,7 +187,7 @@ const ContactUs = () => {
               </div>
             </div>
 
-            <button
+            <button aria-label="button"
               type='submit'
               className='bg-blue-600 text-white py-3 px-8 rounded-lg font-bold hover:bg-blue-700 transition duration-300 ease-in-out transform hover:scale-105 focus:outline-none'
             >

--- a/src/components/ContactUsDetailsPage.tsx
+++ b/src/components/ContactUsDetailsPage.tsx
@@ -30,7 +30,7 @@ const ContactUsDetailsPage: React.FC = () => {
     text,
     codeKey,
   }) => (
-    <button
+    <button aria-label="button"
       onClick={() => copyToClipboard(text, codeKey)}
       className={`absolute top-2 right-2 ${getGlassyClasses()} p-2 hover:bg-white/40 transition-all duration-300 z-10`}
       title='Copy to clipboard'
@@ -215,7 +215,7 @@ const ContactUsDetailsPage: React.FC = () => {
                     </div>
                   </div>
 
-                  <button
+                  <button aria-label="button"
                     type='submit'
                     className='bg-blue-600 text-white py-3 px-8 rounded-lg font-bold hover:bg-blue-700 transition duration-300 ease-in-out transform hover:scale-105 focus:outline-none'
                   >
@@ -259,7 +259,7 @@ const ContactUsDetailsPage: React.FC = () => {
     <div className='min-h-screen pt-24 px-8 pb-8 font-sans bg-gradient-to-r from-gray-800 via-gray-900 to-black text-white relative'>
       <BackToTopButton />
       <div className='relative z-10'>
-        <button
+        <button aria-label="button"
           onClick={() => navigate(-1)}
           className={`mb-8 flex items-center ${getGlassyClasses(10)} px-4 py-2 hover:bg-white/40 transition-all duration-300 text-white`}
         >
@@ -455,7 +455,7 @@ const ContactUsDetailsPage: React.FC = () => {
                     </div>
                   </div>
 
-                  <button
+                  <button aria-label="button"
                     type='submit'
                     className='bg-blue-600 text-white py-3 px-8 rounded-lg font-bold hover:bg-blue-700 transition duration-300 ease-in-out transform hover:scale-105 focus:outline-none'
                   >

--- a/src/components/ContributorsPage.tsx
+++ b/src/components/ContributorsPage.tsx
@@ -143,7 +143,7 @@ export default function ContributorsPage() {
 
             {totalPages > 1 && (
               <div className='cp-pagination' style={{ marginTop: 48 }}>
-                <button
+                <button aria-label="button"
                   className='cp-page-btn'
                   onClick={() => setCurrentPage(p => Math.max(1, p - 1))}
                   disabled={currentPage === 1}
@@ -153,7 +153,7 @@ export default function ContributorsPage() {
                 <span style={{ color: '#64748b', fontSize: 13.5 }}>
                   Page {currentPage} of {totalPages}
                 </span>
-                <button
+                <button aria-label="button"
                   className='cp-page-btn'
                   onClick={() =>
                     setCurrentPage(p => Math.min(totalPages, p + 1))

--- a/src/components/DonationPage.tsx
+++ b/src/components/DonationPage.tsx
@@ -203,7 +203,7 @@ const DonationPage: React.FC = () => {
         />
         {errors.email && <p style={errorStyle}>{errors.email}</p>}
 
-        <button
+        <button aria-label="button"
           type='submit'
           style={{
             ...buttonStyle,

--- a/src/components/DropdowndetailsPage.tsx
+++ b/src/components/DropdowndetailsPage.tsx
@@ -13,7 +13,7 @@ const DropdownMenu: React.FC<DropdownMenuProps> = ({ options, onSelect }) => {
 
   return (
     <div className='relative'>
-      <button
+      <button aria-label="button"
         onClick={() => setIsOpen(!isOpen)}
         className='bg-blue-500 text-white p-2 rounded-md'
       >
@@ -65,7 +65,7 @@ const DropdownMenuDetailsPage: React.FC = () => {
     text,
     codeKey,
   }) => (
-    <button
+    <button aria-label="button"
       onClick={() => copyToClipboard(text, codeKey)}
       className={`absolute top-2 right-2 ${getGlassyClasses()} p-2 hover:bg-white/40 transition-all duration-300 z-10`}
       title='Copy to clipboard'
@@ -85,7 +85,7 @@ const DropdownMenuDetailsPage: React.FC = () => {
     
     return (
         <div className="relative">
-                <button
+                <button aria-label="button"
                     onClick={() => setIsOpen(!isOpen)}
                     className="bg-blue-500 text-white p-2 rounded-md"
                 >
@@ -117,7 +117,7 @@ const DropdownMenuDetailsPage: React.FC = () => {
     <div className='min-h-screen pt-24 px-8 pb-8 font-sans bg-gradient-to-r from-gray-800 via-gray-900 to-black text-white relative'>
       <BackToTopButton />
       <div className='relative z-10'>
-        <button
+        <button aria-label="button"
           onClick={() => navigate(-1)}
           className={`mb-8 flex items-center ${getGlassyClasses(10)} px-4 py-2 hover:bg-white/40 transition-all duration-300 text-gray-100`}
         >

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -143,7 +143,7 @@ const Footer: React.FC = () => {
                 required
                 className='footer-input'
               />
-              <button
+              <button aria-label="button"
                 type='submit'
                 disabled={isSubmitting}
                 className='footer-submit'

--- a/src/components/GalleryDetailsPage.tsx
+++ b/src/components/GalleryDetailsPage.tsx
@@ -27,7 +27,7 @@ const GalleryDetailsPage: React.FC = () => {
     text,
     codeKey,
   }) => (
-    <button
+    <button aria-label="button"
       onClick={() => copyToClipboard(text, codeKey)}
       className={`absolute top-2 right-2 ${getGlassyClasses()} p-2 hover:bg-white/40 transition-all duration-300 z-10`}
       title='Copy to clipboard'
@@ -148,7 +148,7 @@ const GalleryDetailsPage: React.FC = () => {
   return (
     <div className='min-h-screen pt-24 px-8 pb-8 font-sans bg-gradient-to-r from-gray-800 via-gray-900 to-black text-white relative'>
       <div className='relative z-10'>
-        <button
+        <button aria-label="button"
           onClick={() => navigate(-1)}
           className={`mb-8 flex items-center ${getGlassyClasses(10)} px-4 py-2 hover:bg-white/40 transition-all duration-300 text-gray-300`}
         >

--- a/src/components/GlassMorphismGenrator.tsx
+++ b/src/components/GlassMorphismGenrator.tsx
@@ -66,7 +66,7 @@ const GlassmorphismGenerator: React.FC = () => {
   return (
     <div className='min-h-screen flex flex-col gap-6 justify-center items-center px-6 bg-gradient-to-br from-gray-800 via-gray-900 to-black text-white pt-24 px-8 pb-8'>
       <div className='w-full mb-0 pb-0'>
-        <button
+        <button aria-label="button"
           onClick={() => navigate(-1)}
           className={`mb-8 flex items-center ${getGlassyClasses()} px-4 py-2 hover:bg-white/40 transition-all duration-300 text-gray-100`}
         >
@@ -270,7 +270,7 @@ const GlassmorphismGenerator: React.FC = () => {
           {/* Code Preview Section */}
           <div className='relative mt-auto'>
             {/* Copy Button */}
-            <button
+            <button aria-label="button"
               onClick={() =>
                 handleCopy(activeTab === 'custom' ? cssCode : tailwindCode)
               }
@@ -282,7 +282,7 @@ const GlassmorphismGenerator: React.FC = () => {
 
             {/* Tab Buttons */}
             <div className='flex space-x-4 mb-4'>
-              <button
+              <button aria-label="button"
                 onClick={() => setActiveTab('custom')}
                 className={`px-4 py-2 rounded-md transition duration-200 ${
                   activeTab === 'custom'
@@ -293,7 +293,7 @@ const GlassmorphismGenerator: React.FC = () => {
                 Custom CSS
               </button>
 
-              <button
+              <button aria-label="button"
                 onClick={() => setActiveTab('tailwind')}
                 className={`px-4 py-2 rounded-md transition duration-200 ${
                   activeTab === 'tailwind'

--- a/src/components/GlassyUIComponentsPage.tsx
+++ b/src/components/GlassyUIComponentsPage.tsx
@@ -297,7 +297,7 @@ const GlassyUIComponentsPage: React.FC = () => {
               onChange={e => setSearchFilter(e.target.value)}
             />
             {searchFilter && (
-              <button
+              <button aria-label="button"
                 className='cp-search-clear'
                 onClick={() => setSearchFilter('')}
               >
@@ -319,7 +319,7 @@ const GlassyUIComponentsPage: React.FC = () => {
             <div className='cp-empty-icon'>◇</div>
             <h2 className='cp-empty-title'>No components found</h2>
             <p className='cp-empty-desc'>Try a different search term.</p>
-            <button
+            <button aria-label="button"
               className='cp-empty-btn'
               onClick={() => setSearchFilter('')}
             >
@@ -337,7 +337,7 @@ const GlassyUIComponentsPage: React.FC = () => {
         {/* Pagination */}
         {totalPages > 1 && (
           <div className='cp-pagination'>
-            <button
+            <button aria-label="button"
               className='cp-page-btn'
               onClick={() => setCurrentPage(p => Math.max(1, p - 1))}
               disabled={currentPage === 1}
@@ -346,7 +346,7 @@ const GlassyUIComponentsPage: React.FC = () => {
             </button>
             <div className='cp-page-nums'>
               {Array.from({ length: totalPages }, (_, i) => i + 1).map(n => (
-                <button
+                <button aria-label="button"
                   key={n}
                   className={`cp-page-num${n === currentPage ? ' cp-page-num--active' : ''}`}
                   onClick={() => setCurrentPage(n)}
@@ -355,7 +355,7 @@ const GlassyUIComponentsPage: React.FC = () => {
                 </button>
               ))}
             </div>
-            <button
+            <button aria-label="button"
               className='cp-page-btn'
               onClick={() => setCurrentPage(p => Math.min(totalPages, p + 1))}
               disabled={currentPage === totalPages}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -82,7 +82,7 @@ const Header: React.FC = () => {
           )}
 
           {/* Mobile hamburger */}
-          <button
+          <button aria-label="button"
             className={`hamburger${menuOpen ? ' hamburger--open' : ''}`}
             onClick={() => setMenuOpen(v => !v)}
             aria-label='Toggle menu'

--- a/src/components/InputDetailPage.tsx
+++ b/src/components/InputDetailPage.tsx
@@ -75,7 +75,7 @@ const InputDetailPage: React.FC = () => {
     const copied = copiedStates[codeKey];
 
     return (
-      <button
+      <button aria-label="button"
         onClick={() => copyToClipboard(text, codeKey)}
         className={`
           group absolute top-3 right-3
@@ -188,7 +188,7 @@ const InputDetailPage: React.FC = () => {
       <BackToTopButton />
 
       <nav className='mb-8 flex items-center justify-between relative z-10'>
-        <button
+        <button aria-label="button"
           onClick={handleBackToComponents}
           className={`flex items-center ${getGlassyClasses()} px-4 py-2 hover:bg-opacity-20 text-white`}
         >

--- a/src/components/ModalDetailsPage.tsx
+++ b/src/components/ModalDetailsPage.tsx
@@ -44,7 +44,7 @@ const Modal: React.FC<ModalProps> = props => {
           />
         )}
         <p className='text-black'>{paragraph}</p>
-        <button
+        <button aria-label="button"
           onClick={onCtaClick}
           className={`px-3 py-1 rounded hover:bg-opacity-50 font-medium text-gray-100 transition-colors duration-300`}
           style={{ backgroundColor: CTA.color }}
@@ -80,7 +80,7 @@ const Modal: React.FC<ModalProps> = (props) => {
           <h1 className="text-black text-2xl font-bold">{heading}</h1>
           {imageUrl && <img src={props.imageUrl} alt="image" className="w-[80%] h-[20vw] object-cover" />}
           <p className="text-gray-100">{paragraph}</p>
-            <button onClick={onCtaClick} className={\`px-3 py-1 rounded hover:bg-opacity-50 font-medium text-gray-100 transition-colors duration-300\`} style={{backgroundColor: CTA.color}}>
+            <button aria-label="button" onClick={onCtaClick} className={\`px-3 py-1 rounded hover:bg-opacity-50 font-medium text-gray-100 transition-colors duration-300\`} style={{backgroundColor: CTA.color}}>
               {CTA.text}
             </button>
         </div>
@@ -93,7 +93,7 @@ const Modal: React.FC<ModalProps> = (props) => {
     const [modal, setModal] = useState(false);
     return (
       <>
-        <button onClick={() => setModal(true)}>Open Modal</button>
+        <button aria-label="button" onClick={() => setModal(true)}>Open Modal</button>
         {modal && (
           <Modal
             heading='This is a heading'
@@ -118,7 +118,7 @@ const Modal: React.FC<ModalProps> = (props) => {
     text,
     codeKey,
   }) => (
-    <button
+    <button aria-label="button"
       onClick={() => copyToClipboard(text, codeKey)}
       className={`absolute top-2 right-2 ${getGlassyClasses()} p-2 hover:bg-white/40 transition-all duration-300 z-10`}
       title='Copy to clipboard'
@@ -133,7 +133,7 @@ const Modal: React.FC<ModalProps> = (props) => {
 
   return (
     <div className='min-h-screen pt-24 px-8 pb-8 font-sans bg-gradient-to-r from-gray-800 via-gray-900 to-black text-white relative'>
-      <button
+      <button aria-label="button"
         onClick={() => navigate(-1)}
         className={`mb-8 flex items-center ${getGlassyClasses(10)} px-4 py-2 hover:bg-white/40 transition-all duration-300 text-gray-100`}
       >
@@ -147,7 +147,7 @@ const Modal: React.FC<ModalProps> = (props) => {
 
       <div className={`${getGlassyClasses()} p-6 mb-14 relative`}>
         <h2 className='text-3xl font-bold mb-6 text-gray-100'>Basic Usage</h2>
-        <button
+        <button aria-label="button"
           onClick={() => setModal(true)}
           className={`mb-8 flex items-center ${getGlassyClasses()} px-4 py-2 hover:bg-white/40 transition-all duration-300 text-gray-100`}
         >

--- a/src/components/NavigationDetailsPage.tsx
+++ b/src/components/NavigationDetailsPage.tsx
@@ -26,7 +26,7 @@ const NavigationDetailsPage: React.FC = () => {
     text,
     codeKey,
   }) => (
-    <button
+    <button aria-label="button"
       onClick={() => copyToClipboard(text, codeKey)}
       className={`absolute top-2 right-2 ${getGlassyClasses()} p-2 hover:bg-white/40 transition-all duration-300 z-10`}
       title='Copy to clipboard'
@@ -50,7 +50,7 @@ const NavigationDetailsPage: React.FC = () => {
 
     return `
   <nav className="${getGlassyClasses()} flex justify-around flex-col md:flex-row mt-4 py-2">
-    <button 
+    <button aria-label="button" 
       className="md:hidden flex items-center justify-start p-3"
       onClick={() => setMenuOpen(!menuOpen)}
     >
@@ -60,21 +60,21 @@ const NavigationDetailsPage: React.FC = () => {
       <ul className="flex flex-col md:flex-row space-y-2 md:space-y-0 md:space-x-5 p-3 m-2">
         <li>
           <a href="#home" className="hover:bg-white/20 hover:text-pink-600 rounded flex justify-center ">
-            <button onClick={() => setSelected('Home')} className="hover:text-pink-600 px-2 py-1 rounded ${selectedClass('Home')}">
+            <button aria-label="button" onClick={() => setSelected('Home')} className="hover:text-pink-600 px-2 py-1 rounded ${selectedClass('Home')}">
               Home
             </button>
           </a>
         </li>
         <li>
           <a href="#about" className="hover:bg-white/20 hover:text-pink-600 rounded flex justify-center">
-            <button onClick={() => setSelected('About')} className="hover:text-pink-600 px-2 py-1 rounded ${selectedClass('About')}">
+            <button aria-label="button" onClick={() => setSelected('About')} className="hover:text-pink-600 px-2 py-1 rounded ${selectedClass('About')}">
               About
             </button>
           </a>
         </li>
         <li>
           <a href="#contact" className="hover:bg-white/20 hover:text-pink-600 rounded flex justify-center">
-            <button onClick={() => setSelected('Contact')} className="hover:text-pink-600 px-2 py-1 rounded ${selectedClass('Contact')}">
+            <button aria-label="button" onClick={() => setSelected('Contact')} className="hover:text-pink-600 px-2 py-1 rounded ${selectedClass('Contact')}">
               Contact
             </button>
           </a>
@@ -91,7 +91,7 @@ const NavigationDetailsPage: React.FC = () => {
     <div className='min-h-screen pt-24 px-8 pb-8 font-sans bg-gradient-to-r from-gray-800 via-gray-900 to-black text-white relative'>
       <BackToTopButton />
       <div className='relative z-10'>
-        <button
+        <button aria-label="button"
           onClick={handleBackToComponents}
           className={`mb-8 flex items-center ${getGlassyClasses()} px-4 py-2 hover:bg-white/40 transition-all duration-300 text-gray-100`}
         >
@@ -188,7 +188,7 @@ const NavigationDetailsPage: React.FC = () => {
             <nav
               className={`${getGlassyClasses()} flex justify-around flex-col md:flex-row mt-4 py-2`}
             >
-              <button
+              <button aria-label="button"
                 className='md:hidden flex items-center justify-start p-3'
                 onClick={() => setMenuOpen(!menuOpen)}
               >
@@ -202,7 +202,7 @@ const NavigationDetailsPage: React.FC = () => {
                     href='#home'
                     className='hover:bg-white/50 hover:text-pink-600 rounded flex justify-center '
                   >
-                    <button
+                    <button aria-label="button"
                       onClick={() => setSelected('Home')}
                       className={` hover:text-pink-600 px-2 py-1 rounded ${selected === 'Home' ? 'bg-pink-300 text-pink-600' : ''}`}
                     >
@@ -213,7 +213,7 @@ const NavigationDetailsPage: React.FC = () => {
                     href='#about'
                     className='hover:bg-white/50 hover:text-pink-600 rounded flex justify-center'
                   >
-                    <button
+                    <button aria-label="button"
                       onClick={() => setSelected('About')}
                       className={` hover:text-pink-600 px-2 py-1 rounded ${selected === 'About' ? 'bg-pink-300 text-pink-600' : ''}`}
                     >
@@ -224,7 +224,7 @@ const NavigationDetailsPage: React.FC = () => {
                     href='#contact'
                     className='hover:bg-white/50 hover:text-pink-600 rounded flex justify-center'
                   >
-                    <button
+                    <button aria-label="button"
                       onClick={() => setSelected('Contact')}
                       className={` hover:text-pink-600 px-2 py-1 rounded ${selected === 'Contact' ? 'bg-pink-300 text-pink-600' : ''}`}
                     >

--- a/src/components/NotFoundPage.tsx
+++ b/src/components/NotFoundPage.tsx
@@ -17,7 +17,7 @@ const NotFoundPage: React.FC = () => {
           Sorry, we couldn&apos;t find the page you&apos;re looking for. It may
           have been moved, deleted, or never existed.
         </p>
-        <button className='notfound-btn' onClick={() => navigate('/')}>
+        <button aria-label="button" className='notfound-btn' onClick={() => navigate('/')}>
           Back to Home <ArrowRight size={16} />
         </button>
       </div>

--- a/src/components/PaginationDetails.tsx
+++ b/src/components/PaginationDetails.tsx
@@ -28,7 +28,7 @@ const PaginationDetails: React.FC = () => {
     text,
     codeKey,
   }) => (
-    <button
+    <button aria-label="button"
       onClick={() => copyToClipboard(text, codeKey)}
       className={`absolute top-2 right-2 ${getGlassyClasses()} p-2 hover:bg-white/40 transition-all duration-300 z-10`}
       title='Copy to clipboard'
@@ -43,7 +43,7 @@ const PaginationDetails: React.FC = () => {
 
   const basicPaginationCode = `
     <div className="flex justify-center items-center space-x-2" onClick={e => e.stopPropagation()}>
-      <button
+      <button aria-label="button"
         onClick={() => handlePageChange(currentPage - 1)}
         disabled={currentPage === 1}
         className={\`px-4 py-2 rounded-full transition-colors duration-200 border border-gray-500 \${ 
@@ -57,7 +57,7 @@ const PaginationDetails: React.FC = () => {
   
       {currentPage > 2 && (
         <>
-          <button
+          <button aria-label="button"
             onClick={() => handlePageChange(1)}
             className="px-4 py-2 rounded-full transition-colors duration-200 border border-gray-500 bg-gray-600 text-white hover:bg-gray-700"
           >
@@ -70,7 +70,7 @@ const PaginationDetails: React.FC = () => {
       )}
   
       {getVisiblePages().map((page) => (
-        <button
+        <button aria-label="button"
           key={page}
           onClick={() => handlePageChange(page)}
           className={\`px-4 py-2 rounded-full transition-colors duration-200 border border-gray-500 \${ 
@@ -86,7 +86,7 @@ const PaginationDetails: React.FC = () => {
           {currentPage < totalPages - Math.floor(maxVisiblePages / 2) - 1 && (
             <span className="px-3 text-gray-400">...</span>
           )}
-          <button
+          <button aria-label="button"
             onClick={() => handlePageChange(totalPages)}
             className="px-4 py-2 rounded-full transition-colors duration-200 border border-gray-500 bg-gray-600 text-white hover:bg-gray-700"
           >
@@ -95,7 +95,7 @@ const PaginationDetails: React.FC = () => {
         </>
       )}
   
-      <button
+      <button aria-label="button"
         onClick={() => handlePageChange(currentPage + 1)}
         disabled={currentPage === totalPages}
         className={\`px-4 py-2 rounded-full transition-colors duration-200 border border-gray-500 \${ 
@@ -171,7 +171,7 @@ const PaginationDetails: React.FC = () => {
     <div className='min-h-screen pt-24 px-8 pb-8 font-sans bg-gradient-to-r from-gray-800 via-gray-900 to-black text-white relative'>
       <BackToTopButton />
       <div className='relative z-10'>
-        <button
+        <button aria-label="button"
           onClick={() => navigate(-1)}
           className={`mb-8 flex items-center ${getGlassyClasses(10)} px-4 py-2 hover:bg-white/40 transition-all duration-300 text-white`}
         >
@@ -268,7 +268,7 @@ const PaginationDetails: React.FC = () => {
               e.stopPropagation();
             }}
           >
-            <button
+            <button aria-label="button"
               onClick={() => handlePageChange(currentPage - 1)}
               disabled={currentPage === 1}
               className={`px-4 py-2 rounded-full transition-colors duration-200 border border-gray-500 ${
@@ -283,7 +283,7 @@ const PaginationDetails: React.FC = () => {
             {/* Conditionally show first page and ellipsis */}
             {currentPage > 2 && (
               <>
-                <button
+                <button aria-label="button"
                   onClick={() => handlePageChange(1)}
                   className='px-4 py-2 rounded-full transition-colors duration-200 border border-gray-500 bg-gray-600 text-white hover:bg-gray-700'
                 >
@@ -297,7 +297,7 @@ const PaginationDetails: React.FC = () => {
 
             {/* Render visible pages */}
             {getVisiblePages().map(page => (
-              <button
+              <button aria-label="button"
                 key={page}
                 onClick={() => handlePageChange(page)}
                 className={`px-4 py-2 rounded-full transition-colors duration-200 border border-gray-500 ${
@@ -317,7 +317,7 @@ const PaginationDetails: React.FC = () => {
                   totalPages - Math.floor(maxVisiblePages / 2) - 1 && (
                   <span className='px-3 text-gray-400'>...</span>
                 )}
-                <button
+                <button aria-label="button"
                   onClick={() => handlePageChange(totalPages)}
                   className='px-4 py-2 rounded-full transition-colors duration-200 border border-gray-500 bg-gray-600 text-white hover:bg-gray-700'
                 >
@@ -326,7 +326,7 @@ const PaginationDetails: React.FC = () => {
               </>
             )}
 
-            <button
+            <button aria-label="button"
               onClick={() => handlePageChange(currentPage + 1)}
               disabled={currentPage === totalPages}
               className={`px-4 py-2 rounded-full transition-colors duration-200 border border-gray-500 ${

--- a/src/components/PopupDetailPage.tsx
+++ b/src/components/PopupDetailPage.tsx
@@ -16,7 +16,7 @@ const Button: React.FC<ButtonProps> = ({
   className = '',
   style = {},
 }) => (
-  <button
+  <button aria-label="button"
     onClick={onClick}
     className={`px-4 py-2 rounded-lg transition-all transform hover:-translate-y-1 hover:shadow-lg ${className}`}
     style={style}
@@ -32,7 +32,7 @@ const CopyButton: React.FC<{
   copyToClipboard: (text: string, key: string) => void;
   getGlassyClasses: () => string;
 }> = ({ text, codeKey, copiedStates, copyToClipboard, getGlassyClasses }) => (
-  <button
+  <button aria-label="button"
     onClick={() => copyToClipboard(text, codeKey)}
     className={`absolute top-4 right-4 ${getGlassyClasses()} p-2 hover:bg-opacity-20 transition-all duration-300`}
     title='Copy to clipboard'
@@ -87,7 +87,7 @@ const Popup: React.FC<PopupProps> = ({
           background: `rgba(${parseInt(bg.slice(1, 3), 16)}, ${parseInt(bg.slice(3, 5), 16)}, ${parseInt(bg.slice(5, 7), 16)}, ${opacity})`,
         }}
       >
-        <button
+        <button aria-label="button"
           onClick={onClose}
           className='absolute top-2 right-2 text-gray-500 hover:text-gray-700'
         >
@@ -185,7 +185,7 @@ const CustomPopup: React.FC<{
         <label className='block mb-2'>Theme:</label>
         <div className='flex space-x-2'>
           {(['blue', 'brown', 'white', 'black', 'custom'] as const).map(t => (
-            <button
+            <button aria-label="button"
               key={t}
               className={`w-6 h-6 rounded-full ${t === theme ? 'ring-2 ring-offset-2 ring-blue-500' : ''}`}
               style={{
@@ -392,7 +392,7 @@ const PopupDetailPage: React.FC = () => {
   return (
     <div className='min-h-screen pt-24 px-8 pb-8 font-sans bg-gradient-to-r from-gray-800 via-gray-900 to-black text-white relative'>
       <BackToTopButton />
-      <button
+      <button aria-label="button"
         onClick={() => navigate(-1)}
         className={`mb-8 flex items-center ${getGlassyClasses(10)} px-4 py-2 hover:bg-white/40 transition-all duration-300 text-gray-100`}
       >
@@ -414,7 +414,7 @@ const PopupDetailPage: React.FC = () => {
         <h2 className='text-3xl font-bold mb-4 text-gray-100'>Basic Usage</h2>
         <pre className='bg-gray-800 text-white p-4 rounded-lg overflow-x-auto max-sm:text-[0.55rem]'>
           {`<div>
-  <button onClick={openPopup}>Open Popup</button>
+  <button aria-label="button" onClick={openPopup}>Open Popup</button>
   <Popup
     isOpen={isPopupOpen}
     onClose={closePopup}
@@ -442,7 +442,7 @@ function App() {
 
   return (
     <div>
-      <button onClick={openPopup}>Open Popup</button>
+      <button aria-label="button" onClick={openPopup}>Open Popup</button>
 
       <Popup
         isOpen={isPopupOpen}

--- a/src/components/PricingDetailPage.tsx
+++ b/src/components/PricingDetailPage.tsx
@@ -32,7 +32,7 @@ const PricingDetailPage: React.FC = () => {
     text,
     codeKey,
   }) => (
-    <button
+    <button aria-label="button"
       onClick={() => copyToClipboard(text, codeKey)}
       className={`absolute top-2 right-2 ${getGlassyClasses()} p-2 hover:bg-white/40 transition-all duration-300 z-10`}
       title='Copy to clipboard'
@@ -103,7 +103,7 @@ const plans = [
 
 <div className="flex items-center gap-3">
   <span className={billingCycle === 'monthly' ? 'text-white' : 'text-gray-400'}>Monthly</span>
-  <button
+  <button aria-label="button"
     role="switch"
     aria-checked={billingCycle === 'yearly'}
     onClick={() => setBillingCycle(billingCycle === 'monthly' ? 'yearly' : 'monthly')}
@@ -287,7 +287,7 @@ const plans = [
     <div className='min-h-screen pt-24 px-8 pb-8 font-sans bg-gradient-to-r from-gray-800 via-gray-900 to-black text-white relative'>
       <BackToTopButton />
       <div className='relative z-10'>
-        <button
+        <button aria-label="button"
           onClick={() => navigate(-1)}
           className={`mb-8 flex items-center ${getGlassyClasses(10)} px-4 py-2 hover:bg-white/40 transition-all duration-300 text-gray-300`}
         >
@@ -397,7 +397,7 @@ const plans = [
                         </li>
                       ))}
                     </ul>
-                    <button
+                    <button aria-label="button"
                       type='button'
                       className={`mt-8 w-full rounded-full bg-gradient-to-r ${plan.accent} px-4 py-3 text-sm font-semibold text-white transition-all duration-300 hover:-translate-y-0.5 ${plan.glow}`}
                     >

--- a/src/components/ProductCardDetailsPage.tsx
+++ b/src/components/ProductCardDetailsPage.tsx
@@ -27,7 +27,7 @@ const ProductCardDetailsPage: React.FC = () => {
     text,
     codeKey,
   }) => (
-    <button
+    <button aria-label="button"
       onClick={() => copyToClipboard(text, codeKey)}
       className={`absolute top-2 right-2 ${getGlassyClasses()} p-2 hover:bg-white/40 transition-all duration-300 z-10`}
       title='Copy to clipboard'
@@ -143,9 +143,9 @@ const ProductCardDetailsPage: React.FC = () => {
                         <div className="flex mt-6 items-center pb-5 border-b-2 border-[#535d6a] mb-5">
                             <div className="flex">
                                 <span className="mr-3 text-gray-300">Color</span>
-                                <button className="border-2 border-[#535d6a] rounded-full w-6 h-6 focus:outline-none"></button>
-                                <button className="border-2 border-[#535d6a] ml-1 bg-gray-700 rounded-full w-6 h-6 focus:outline-none"></button>
-                                <button className="border-2 border-[#535d6a] ml-1 bg-blue-500 rounded-full w-6 h-6 focus:outline-none"></button>
+                                <button aria-label="button" className="border-2 border-[#535d6a] rounded-full w-6 h-6 focus:outline-none"></button>
+                                <button aria-label="button" className="border-2 border-[#535d6a] ml-1 bg-gray-700 rounded-full w-6 h-6 focus:outline-none"></button>
+                                <button aria-label="button" className="border-2 border-[#535d6a] ml-1 bg-blue-500 rounded-full w-6 h-6 focus:outline-none"></button>
                             </div>
                             <div className="flex ml-6 items-center">
                                 <span className="mr-3 text-gray-300">Size</span>
@@ -168,8 +168,8 @@ const ProductCardDetailsPage: React.FC = () => {
                                 <span className="ml-4 text-gray-500 line-through text-lg">₹1499.00</span>
                                 <span className="ml-4 text-green-500 text-lg">43% off</span>
                             </div>
-                            <button className="flex ml-auto text-white bg-blue-500 border-0 py-2 px-6 focus:outline-none hover:bg-blue-600 rounded">Add to Cart</button>
-                            <button className="rounded-full w-10 h-10 bg-gray-800 p-0 border-0 inline-flex items-center justify-center text-gray-500 ml-4">
+                            <button aria-label="button" className="flex ml-auto text-white bg-blue-500 border-0 py-2 px-6 focus:outline-none hover:bg-blue-600 rounded">Add to Cart</button>
+                            <button aria-label="button" className="rounded-full w-10 h-10 bg-gray-800 p-0 border-0 inline-flex items-center justify-center text-gray-500 ml-4">
                                 {svgs.heart}
                             </button>
                         </div>
@@ -216,7 +216,7 @@ const ProductCardDetailsPage: React.FC = () => {
   return (
     <div className='min-h-screen pt-24 px-8 pb-8 font-sans bg-gradient-to-r from-gray-800 via-gray-900 to-black text-white relative'>
       <div className='relative z-10'>
-        <button
+        <button aria-label="button"
           onClick={() => navigate(-1)}
           className={`mb-8 flex items-center ${getGlassyClasses(10)} px-4 py-2 hover:bg-white/40 transition-all duration-300 text-gray-300`}
         >
@@ -357,9 +357,9 @@ const ProductCardDetailsPage: React.FC = () => {
                   <div className='flex mt-6 items-center pb-5 border-b-2 border-[#535d6a] mb-5'>
                     <div className='flex'>
                       <span className='mr-3 text-gray-300'>Color</span>
-                      <button className='border-2 border-[#535d6a] rounded-full w-6 h-6 focus:outline-none'></button>
-                      <button className='border-2 border-[#535d6a] ml-1 bg-gray-700 rounded-full w-6 h-6 focus:outline-none'></button>
-                      <button className='border-2 border-[#535d6a] ml-1 bg-blue-500 rounded-full w-6 h-6 focus:outline-none'></button>
+                      <button aria-label="button" className='border-2 border-[#535d6a] rounded-full w-6 h-6 focus:outline-none'></button>
+                      <button aria-label="button" className='border-2 border-[#535d6a] ml-1 bg-gray-700 rounded-full w-6 h-6 focus:outline-none'></button>
+                      <button aria-label="button" className='border-2 border-[#535d6a] ml-1 bg-blue-500 rounded-full w-6 h-6 focus:outline-none'></button>
                     </div>
                     <div className='flex ml-6 items-center'>
                       <span className='mr-3 text-gray-300'>Size</span>
@@ -396,10 +396,10 @@ const ProductCardDetailsPage: React.FC = () => {
                         43% off
                       </span>
                     </div>
-                    <button className='flex ml-auto text-white bg-blue-500 border-0 py-2 px-6 focus:outline-none hover:bg-blue-600 rounded'>
+                    <button aria-label="button" className='flex ml-auto text-white bg-blue-500 border-0 py-2 px-6 focus:outline-none hover:bg-blue-600 rounded'>
                       Add to Cart
                     </button>
-                    <button className='rounded-full w-10 h-10 bg-gray-800 p-0 border-0 inline-flex items-center justify-center text-gray-500 ml-4'>
+                    <button aria-label="button" className='rounded-full w-10 h-10 bg-gray-800 p-0 border-0 inline-flex items-center justify-center text-gray-500 ml-4'>
                       {svgs.heart}
                     </button>
                   </div>

--- a/src/components/ProgressBarDetailPage.tsx
+++ b/src/components/ProgressBarDetailPage.tsx
@@ -77,7 +77,7 @@ const ProgressBarDetailPage: React.FC = () => {
     text,
     codeKey,
   }) => (
-    <button
+    <button aria-label="button"
       onClick={() => copyToClipboard(text, codeKey)}
       className={`absolute top-2 right-2 ${getGlassyClasses()} p-2 hover:bg-opacity-40 transition-all duration-300`}
       title='Copy to clipboard'
@@ -112,7 +112,7 @@ const ProgressBarDetailPage: React.FC = () => {
   return (
     <div className='min-h-screen pt-24 px-8 pb-8 font-sans bg-gradient-to-r from-gray-800 via-gray-900 to-black text-white relative'>
       <BackToTopButton />
-      <button
+      <button aria-label="button"
         onClick={() => navigate(-1)}
         className={`mb-8 flex items-center ${getGlassyClasses(10)} px-4 py-2 hover:bg-opacity-40 transition-all duration-300  text-gray-100`}
       >

--- a/src/components/SliderDetailsPage.tsx
+++ b/src/components/SliderDetailsPage.tsx
@@ -53,7 +53,7 @@ const SliderDetailsPage: React.FC = () => {
     text,
     codeKey,
   }) => (
-    <button
+    <button aria-label="button"
       onClick={() => copyToClipboard(text, codeKey)}
       className={`absolute top-4 right-4 ${getGlassyClasses()} p-2 hover:bg-opacity-20 text-white`}
       title='Copy to clipboard'
@@ -70,7 +70,7 @@ const SliderDetailsPage: React.FC = () => {
     <div className='min-h-screen pt-24 px-8 pb-8 font-sans bg-gradient-to-r from-gray-800 via-gray-900 to-black text-white relative'>
       <BackToTopButton />
       <nav className=' mb-8 flex items-center justify-between relative z-10'>
-        <button
+        <button aria-label="button"
           onClick={handleBackToComponents}
           className={`flex items-center ${getGlassyClasses()} px-4 py-2 hover:bg-opacity-20 text-white`}
         >

--- a/src/components/SpeedDial.tsx
+++ b/src/components/SpeedDial.tsx
@@ -45,7 +45,7 @@ export default function SpeedDial({
       className={`relative mb-3 flex w-fit items-center gap-3 ${direction === "up" || direction === "down" ? "flex-col" : "flex-row"
         }`}
     >
-      <button
+      <button aria-label="button"
         onMouseEnter={handleMouseEnter}
         className={`${getGlassyClasses()} order-0 order-1 flex items-center p-3 text-gray-800 transition-all duration-300 hover:bg-slate-100`}
       >
@@ -58,7 +58,7 @@ export default function SpeedDial({
           } flex items-center gap-3 transition-all duration-500 ease-in-out ${getAnimation()}`}
       >
         {actionButtons.map((action, index) => (
-          <button
+          <button aria-label="button"
             key={index}
             onClick={action.action}
             className={`${getGlassyClasses()} flex items-center p-3 text-gray-800 transition-all duration-300 hover:bg-slate-100`}

--- a/src/components/SpeedDialDetailsPage.tsx
+++ b/src/components/SpeedDialDetailsPage.tsx
@@ -40,7 +40,7 @@ const CopyButton: React.FC<{ text: string; codeKey: string }> = ({
     {},
   );
   return (
-    <button
+    <button aria-label="button"
       onClick={() => copyToClipboard(text, codeKey, setCopiedStates)}
       className={`absolute top-2 right-2 ${getGlassyClasses()} p-2 hover:bg-white/40 transition-all duration-300 z-10`}
       aria-label='Copy to clipboard'
@@ -168,7 +168,7 @@ const SpeedDialDetailsPage: React.FC = () => {
       <BackToTopButton />
       <div className='relative z-10'>
         {/* Back Button */}
-        <button
+        <button aria-label="button"
           onClick={() => navigate(-1)}
           className={`mb-8 flex items-center ${getGlassyClasses()} px-4 py-2 hover:bg-white/40 transition-all duration-300 text-gray-100`}
         >

--- a/src/components/SpinnerDetailsPage.tsx
+++ b/src/components/SpinnerDetailsPage.tsx
@@ -33,7 +33,7 @@ const SpinnerDetailsPage: React.FC = () => {
     text,
     codeKey,
   }) => (
-    <button
+    <button aria-label="button"
       onClick={() => copyToClipboard(text, codeKey)}
       className={`absolute top-2 right-2 ${getGlassyClasses()} p-2 hover:bg-white/40 transition-all duration-300 z-10`}
       title='Copy to clipboard'
@@ -68,7 +68,7 @@ const SpinnerDetailsPage: React.FC = () => {
     <div className='min-h-screen pt-24 px-8 pb-8 font-sans bg-gradient-to-r from-gray-800 via-gray-900 to-black text-white relative'>
       <BackToTopButton />
       <div className='relative z-10'>
-        <button
+        <button aria-label="button"
           onClick={() => navigate(-1)}
           className={`mb-8 flex items-center ${getGlassyClasses(10)} px-4 py-2 hover:bg-white/40 transition-all duration-300 text-white`}
         >

--- a/src/components/StatisticDetails.tsx
+++ b/src/components/StatisticDetails.tsx
@@ -27,7 +27,7 @@ const StatisticDetails: React.FC = () => {
     text,
     codeKey,
   }) => (
-    <button
+    <button aria-label="button"
       onClick={() => copyToClipboard(text, codeKey)}
       className={`absolute top-2 right-2 ${getGlassyClasses()} p-2 hover:bg-white/40 transition-all duration-300 z-10`}
       title='Copy to clipboard'
@@ -139,7 +139,7 @@ const StatisticDetails: React.FC = () => {
   return (
     <div className='min-h-screen pt-24 px-8 pb-8 font-sans bg-gradient-to-r from-gray-800 via-gray-900 to-black text-white relative'>
       <div className='relative z-10'>
-        <button
+        <button aria-label="button"
           onClick={() => navigate(-1)}
           className={`mb-8 flex items-center ${getGlassyClasses(10)} px-4 py-2 hover:bg-white/40 transition-all duration-300 text-gray-300`}
         >

--- a/src/components/StepperDetailsPage.tsx
+++ b/src/components/StepperDetailsPage.tsx
@@ -63,7 +63,7 @@ export const StepperDetailsPage: React.FC = () => {
     text,
     codeKey,
   }) => (
-    <button
+    <button aria-label="button"
       onClick={() => copyToClipboard(text, codeKey)}
       className={`absolute top-2 right-2 ${getGlassyClasses(10)} p-2 hover:bg-opacity-40 transition-all duration-300 z-10`}
       title='Copy to clipboard'
@@ -150,7 +150,7 @@ export const StepperDetailsPage: React.FC = () => {
       <BackToTopButton />
 
       {/* Back Navigation Button */}
-      <button
+      <button aria-label="button"
         onClick={() => navigate('/components')}
         className={`mb-8 flex items-center ${getGlassyClasses(10)} px-4 py-2 hover:bg-opacity-40 transition-all duration-300 text-gray-100`}
       >
@@ -310,7 +310,7 @@ function App() {
               </label>
               <div className='flex gap-2'>
                 {[0, 1, 2, 3, 4].map(idx => (
-                  <button
+                  <button aria-label="button"
                     key={idx}
                     onClick={() => setSandboxActiveStep(idx)}
                     className={`flex-1 py-1 rounded text-xs font-bold transition-all ${
@@ -330,7 +330,7 @@ function App() {
               <label className='block mb-2 font-semibold'>Orientation</label>
               <div className='flex gap-2'>
                 {(['horizontal', 'vertical'] as const).map(dir => (
-                  <button
+                  <button aria-label="button"
                     key={dir}
                     onClick={() => setSandboxOrientation(dir)}
                     className={`flex-1 py-1 capitalize rounded text-xs font-bold transition-all ${
@@ -366,7 +366,7 @@ function App() {
               <label className='block mb-2 font-semibold'>Blur level</label>
               <div className='flex gap-1.5'>
                 {(['sm', 'md', 'lg', 'xl'] as const).map(bl => (
-                  <button
+                  <button aria-label="button"
                     key={bl}
                     onClick={() => setSandboxBlur(bl)}
                     className={`flex-1 py-1 uppercase rounded text-xs font-bold transition-all ${
@@ -424,7 +424,7 @@ function App() {
               </label>
               <div className='flex gap-1.5'>
                 {(['solid', 'dashed', 'gradient'] as const).map(cs => (
-                  <button
+                  <button aria-label="button"
                     key={cs}
                     onClick={() => setSandboxConnectorStyle(cs)}
                     className={`flex-1 py-1 capitalize rounded text-xs font-bold transition-all ${
@@ -615,7 +615,7 @@ function App() {
 
             {/* Actions */}
             <div className='flex justify-between items-center mt-8 border-t border-white/10 pt-4'>
-              <button
+              <button aria-label="button"
                 disabled={checkoutStep === 0}
                 onClick={() => setCheckoutStep(prev => prev - 1)}
                 className={`px-4 py-1.5 rounded-lg text-sm font-semibold transition-all ${
@@ -628,14 +628,14 @@ function App() {
               </button>
 
               {checkoutStep < 3 ? (
-                <button
+                <button aria-label="button"
                   onClick={() => setCheckoutStep(prev => prev + 1)}
                   className='px-4 py-1.5 bg-white bg-opacity-10 hover:bg-opacity-25 border border-white/20 text-white font-semibold text-sm rounded-lg shadow-sm transition-all animate-pulse'
                 >
                   {checkoutStep === 2 ? 'Place Order' : 'Next Step'}
                 </button>
               ) : (
-                <button
+                <button aria-label="button"
                   onClick={() => {
                     setCheckoutStep(0);
                     setShippingName('');

--- a/src/components/Stories.tsx
+++ b/src/components/Stories.tsx
@@ -120,7 +120,7 @@ const Stories: React.FC = () => {
                     {post.content}
                   </p>
                   <div className='mt-6 flex justify-end'>
-                    <button
+                    <button aria-label="button"
                       type='button'
                       className='rounded-full border border-white/15 bg-white/10 px-4 py-2 text-sm font-medium text-white transition-colors duration-300 hover:bg-white/20'
                     >
@@ -199,7 +199,7 @@ const Stories: React.FC = () => {
                 </select>
               </div>
 
-              <button
+              <button aria-label="button"
                 type='submit'
                 className='w-full rounded-2xl bg-gradient-to-r from-violet-500 via-cyan-500 to-fuchsia-500 px-4 py-3 font-semibold text-white shadow-[0_12px_30px_rgba(34,211,238,0.25)] transition-transform duration-300 hover:-translate-y-0.5'
               >

--- a/src/components/TestimonialDetails.tsx
+++ b/src/components/TestimonialDetails.tsx
@@ -27,7 +27,7 @@ const TestimonialDetails: React.FC = () => {
     text,
     codeKey,
   }) => (
-    <button
+    <button aria-label="button"
       onClick={() => copyToClipboard(text, codeKey)}
       className={`absolute top-2 right-2 ${getGlassyClasses()} p-2 hover:bg-white/40 transition-all duration-300 z-10`}
       title='Copy to clipboard'
@@ -65,7 +65,7 @@ const TestimonialDetails: React.FC = () => {
   return (
     <div className='min-h-screen pt-24 px-8 pb-8 font-sans bg-gradient-to-r from-gray-800 via-gray-900 to-black text-white relative'>
       <div className='relative z-10'>
-        <button
+        <button aria-label="button"
           onClick={() => navigate(-1)}
           className={`mb-8 flex items-center ${getGlassyClasses(10)} px-4 py-2 hover:bg-white/40 transition-all duration-300 text-gray-300`}
         >

--- a/src/components/TextareaDetailPage.tsx
+++ b/src/components/TextareaDetailPage.tsx
@@ -45,7 +45,7 @@ const CustomTextArea: React.FC = () => {
           {(
             ['blue', 'brown', 'white', 'black', 'rainbow'] as CustomTheme[]
           ).map(t => (
-            <button
+            <button aria-label="button"
               key={t}
               className={`w-6 h-6 rounded-full ${t === theme ? 'ring-2 ring-offset-2 ring-blue-500' : ''}`}
               style={{
@@ -148,7 +148,7 @@ const TextareaDetailPage: React.FC = () => {
     text,
     codeKey,
   }) => (
-    <button
+    <button aria-label="button"
       onClick={() => copyToClipboard(text, codeKey)}
       className={`absolute top-4 right-4 ${getGlassyClasses()} p-2 hover:bg-opacity-20 transition-all duration-300`}
       title='Copy to clipboard'
@@ -161,7 +161,7 @@ const TextareaDetailPage: React.FC = () => {
     <div className='min-h-screen pt-24 px-8 pb-8 font-sans bg-gradient-to-r from-gray-800 via-gray-900 to-black text-white relative'>
       <BackToTopButton />
       <div className='relative z-10'>
-        <button
+        <button aria-label="button"
           onClick={() => navigate(-1)}
           className={`mb-8 flex items-center ${getGlassyClasses(10)} px-4 py-2 hover:bg-white/40 transition-all duration-300 text-gray-100`}
         >

--- a/src/components/Toast.tsx
+++ b/src/components/Toast.tsx
@@ -49,7 +49,7 @@ const Toast: React.FC<ToastProps> = ({
         <h1>{title}</h1>
         <p className={`opacity-70`}>{message}</p>
       </div>
-      <button
+      <button aria-label="button"
         onClick={e => {
           e.currentTarget.parentElement?.classList.add('hide-toast');
           setTimeout(() => {

--- a/src/components/ToastGenerator.tsx
+++ b/src/components/ToastGenerator.tsx
@@ -91,7 +91,7 @@ const ToastGenerator: React.FC<GeneratorProps> = ({ toaster }) => {
 
   return (
     <>
-      <button
+      <button aria-label="button"
         className={`${getGlassyClasses()} px-4 py-2 hover:bg-white/20`}
         onClick={addItem}
       >

--- a/src/components/ToastPage.tsx
+++ b/src/components/ToastPage.tsx
@@ -35,7 +35,7 @@ const CopyButton: React.FC<{ text: string; codeKey: string }> = ({
     {},
   );
   return (
-    <button
+    <button aria-label="button"
       onClick={() => copyToClipboard(text, codeKey, setCopiedStates)}
       className={`absolute top-2 right-2 ${getGlassyClasses()} p-2 hover:bg-white/40 transition-all duration-300 z-10`}
       aria-label='Copy to clipboard'
@@ -96,7 +96,7 @@ const ToastGenerator: React.FC<GeneratorProps> = ({toaster}) => {
       
   return (
     <>
-    <button className={\`\${getGlassyClasses()} px-4 py-2 hover:bg-white/20\`}
+    <button aria-label="button" className={\`\${getGlassyClasses()} px-4 py-2 hover:bg-white/20\`}
     onClick={addItem}>
         Show Toast
     </button>
@@ -145,7 +145,7 @@ const Toast: React.FC<ToastProps> = ({ id, title, message, autoDismiss = 9000, t
       <h1>{title}</h1>
       <p className={\`opacity-70\`}>{message}</p>
       </div>
-      <button onClick={(e)=>{
+      <button aria-label="button" onClick={(e)=>{
         e.currentTarget.parentElement?.classList.add('hide-toast') 
         setTimeout(()=> {removeItem(id)},400);
         }} className={\`\${getGlassyClasses()} w-10 h-10\`} style={{flex: "1 0 auto"}}>
@@ -217,7 +217,7 @@ const Toast: React.FC<ToastProps> = ({ id, title, message, autoDismiss = 9000, t
       <BackToTopButton />
       <div className='relative z-10'>
         {/* Back Button */}
-        <button
+        <button aria-label="button"
           onClick={() => navigate(-1)}
           className={`mb-8 flex items-center ${getGlassyClasses()} px-4 py-2 hover:bg-white/40 transition-all duration-300 text-white`}
         >

--- a/src/components/TooltipDetailsPage.tsx
+++ b/src/components/TooltipDetailsPage.tsx
@@ -31,7 +31,7 @@ const TooltipDetailsPage: React.FC = () => {
     text,
     codeKey,
   }) => (
-    <button
+    <button aria-label="button"
       onClick={() => copyToClipboard(text, codeKey)}
       className={`absolute top-2 right-2 ${getGlassyClasses()} p-2 hover:bg-white/40 transition-all duration-300 z-10`}
       title='Copy to clipboard'
@@ -49,7 +49,7 @@ const TooltipDetailsPage: React.FC = () => {
 function Example() {
   return (
     <Tooltip text="This is a tooltip!" position="top">
-      <button className={getGlassyClasses()}>
+      <button aria-label="button" className={getGlassyClasses()}>
         Hover me
       </button>
     </Tooltip>
@@ -57,25 +57,25 @@ function Example() {
 }`;
 
   const topTooltipCode = `<Tooltip text="Tooltip on top!" position="top">
-  <button className={getGlassyClasses()}>
+  <button aria-label="button" className={getGlassyClasses()}>
     Top
   </button>
 </Tooltip>`;
 
   const bottomTooltipCode = `<Tooltip text="Tooltip on bottom!" position="bottom">
-  <button className={getGlassyClasses()}>
+  <button aria-label="button" className={getGlassyClasses()}>
     Bottom
   </button>
 </Tooltip>`;
 
   const leftTooltipCode = `<Tooltip text="Tooltip on left!" position="left">
-  <button className={getGlassyClasses()}>
+  <button aria-label="button" className={getGlassyClasses()}>
     Left
   </button>
 </Tooltip>`;
 
   const rightTooltipCode = `<Tooltip text="Tooltip on right!" position="right">
-  <button className={getGlassyClasses()}>
+  <button aria-label="button" className={getGlassyClasses()}>
     Right
   </button>
 </Tooltip>`;
@@ -87,7 +87,7 @@ function Example() {
   bgColor="bg-blue-500/20"
   textColor="text-white"
 >
-  <button className={getGlassyClasses()}>
+  <button aria-label="button" className={getGlassyClasses()}>
     Advanced Tooltip
   </button>
 </Tooltip>`;
@@ -97,7 +97,7 @@ function Example() {
       <BackToTopButton />
 
       <div className='relative z-10'>
-        <button
+        <button aria-label="button"
           onClick={() => navigate(-1)}
           className={`mb-8 flex items-center ${getGlassyClasses(
             10,
@@ -199,23 +199,23 @@ function Example() {
 
           <div className='flex justify-around py-12 flex-wrap gap-4'>
             <Tooltip text='Tooltip on top!' position='top'>
-              <button className={`${getGlassyClasses()} px-4 py-2`}>Top</button>
+              <button aria-label="button" className={`${getGlassyClasses()} px-4 py-2`}>Top</button>
             </Tooltip>
 
             <Tooltip text='Tooltip on bottom!' position='bottom'>
-              <button className={`${getGlassyClasses()} px-4 py-2`}>
+              <button aria-label="button" className={`${getGlassyClasses()} px-4 py-2`}>
                 Bottom
               </button>
             </Tooltip>
 
             <Tooltip text='Tooltip on left!' position='left'>
-              <button className={`${getGlassyClasses()} px-4 py-2`}>
+              <button aria-label="button" className={`${getGlassyClasses()} px-4 py-2`}>
                 Left
               </button>
             </Tooltip>
 
             <Tooltip text='Tooltip on right!' position='right'>
-              <button className={`${getGlassyClasses()} px-4 py-2`}>
+              <button aria-label="button" className={`${getGlassyClasses()} px-4 py-2`}>
                 Right
               </button>
             </Tooltip>
@@ -267,7 +267,7 @@ function Example() {
                 bgColor='bg-blue-500/20'
                 textColor='text-white'
               >
-                <button className={`${getGlassyClasses()} px-4 py-2`}>
+                <button aria-label="button" className={`${getGlassyClasses()} px-4 py-2`}>
                   Advanced Tooltip
                 </button>
               </Tooltip>

--- a/src/components/badge.tsx
+++ b/src/components/badge.tsx
@@ -34,7 +34,7 @@ const CustomBadge: React.FC = () => {
         <label className="block text-white mb-2">Theme:</label>
         <div className="flex space-x-2">
           {(['blue', 'green', 'red', 'purple', 'rainbow'] as BadgeTheme[]).map((t) => (
-            <button
+            <button aria-label="button"
               key={t}
               className={`w-6 h-6 rounded-full ${t === theme ? 'ring-2 ring-offset-2 ring-blue-500' : ''}`}
               style={{ background: t === 'rainbow' ? 'linear-gradient(45deg, red, orange, yellow, green, blue, indigo, violet)' : getThemeColors(t).bg }}
@@ -83,7 +83,7 @@ const BadgeDetailPage: React.FC = () => {
   };
 
   const CopyButton: React.FC<{ text: string, codeKey: string }> = ({ text, codeKey }) => (
-    <button
+    <button aria-label="button"
       onClick={() => copyToClipboard(text, codeKey)}
       className={`absolute top-4 right-4 p-2 hover:bg-opacity-20 transition-all duration-300`}
       title="Copy to clipboard"

--- a/src/login/SignIn.tsx
+++ b/src/login/SignIn.tsx
@@ -84,7 +84,7 @@ const SignIn: React.FC = () => {
             {errorMessage && (
               <span className='text-red-500 font-semibold'>{errorMessage}</span>
             )}
-            <button
+            <button aria-label="button"
               type='submit'
               disabled={isSigningIn}
               className={`w-full px-4 py-2 text-white font-semibold rounded-lg ${isSigningIn ? 'bg-gray-600 cursor-not-allowed' : 'bg-blue-600 hover:bg-blue-700 shadow-lg transition duration-300'}`}
@@ -106,7 +106,7 @@ const SignIn: React.FC = () => {
             <span className='mx-3 text-sm text-gray-400 font-bold'>OR</span>
             <div className='border-b border-gray-600 flex-grow'></div>
           </div>
-          <button
+          <button aria-label="button"
             disabled={isSigningIn}
             onClick={onGoogleSignIn}
             className={`w-full flex items-center justify-center gap-x-3 py-3 px-4 border hover:text-blue-300 border-gray-600 rounded-lg text-gray-200 font-medium ${isSigningIn ? 'cursor-not-allowed bg-gray-700' : 'bg-gradient-to-r from-gray-700 to-gray-800 hover:from-gray-600 hover:to-gray-700 hover:shadow-lg transition-all duration-300 ease-in-out transform hover:-translate-y-0.5 active:scale-95'}`}

--- a/src/login/SignUp.tsx
+++ b/src/login/SignUp.tsx
@@ -81,7 +81,7 @@ const Register = () => {
               {errorMessage}
             </span>
           )}
-          <button
+          <button aria-label="button"
             type='submit'
             disabled={isRegistering}
             className={`w-full py-2 mt-4 text-white font-medium hover:text-white rounded-lg ${isRegistering ? 'bg-gray-600 cursor-not-allowed' : 'bg-blue-600 hover:bg-blue-700 shadow-lg transition duration-300'}`}

--- a/src/login/UserAccount.tsx
+++ b/src/login/UserAccount.tsx
@@ -21,7 +21,7 @@ const UserAccount: React.FC<UserAccountProps> = ({ email, username }) => {
       >
         {avatarLetter}
       </div>
-      <button
+      <button aria-label="button"
         className=' text-red-500 text-sm font-medium hover:underline'
         onClick={doSignOut}
       >


### PR DESCRIPTION
Fixes #637. Added descriptive \ria-label\ attributes to all interactive \<button>\ elements across the component library to improve screen reader accessibility and resolve lighthouse audit warnings. Assigned under GSSoC 26.