### PR TITLE
[Bug] Resolve unhandled promise rejections across multiple files

### DIFF
--- a/src/components/AccordionDetails.tsx
+++ b/src/components/AccordionDetails.tsx
@@ -72,7 +72,7 @@ const AccordionDetails: React.FC = () => {
         () => setCopiedStates(prev => ({ ...prev, [key]: false })),
         2000,
       );
-    });
+    }).catch((err) => console.error("Failed to copy text: ", err));
   };
 
   const CopyButton: React.FC<{ text: string; codeKey: string }> = ({

--- a/src/components/AuthenticationCards.tsx
+++ b/src/components/AuthenticationCards.tsx
@@ -62,7 +62,7 @@ const AuthenticationCardDetailsPage: React.FC = () => {
         () => setCopiedStates(prev => ({ ...prev, [key]: false })),
         2000,
       );
-    });
+    }).catch((err) => console.error("Failed to copy text: ", err));
   };
 
   const CopyButton: React.FC<{ text: string; codeKey: string }> = ({

--- a/src/components/BackToTopDetailsPage.tsx
+++ b/src/components/BackToTopDetailsPage.tsx
@@ -21,7 +21,7 @@ const BackToTopDetailsPage: React.FC = () => {
         () => setCopiedStates(prev => ({ ...prev, [key]: false })),
         2000,
       );
-    });
+    }).catch((err) => console.error("Failed to copy text: ", err));
   };
 
   const CopyButton: React.FC<{ text: string; codeKey: string }> = ({

--- a/src/components/ButtonDetailsPage.tsx
+++ b/src/components/ButtonDetailsPage.tsx
@@ -26,7 +26,7 @@ const ButtonDetailsPage: React.FC = () => {
         () => setCopiedStates(prev => ({ ...prev, [key]: false })),
         2000,
       );
-    });
+    }).catch((err) => console.error("Failed to copy text: ", err));
   };
 
   const CopyButton: React.FC<{ text: string; codeKey: string }> = ({

--- a/src/components/CalendarDetails.tsx
+++ b/src/components/CalendarDetails.tsx
@@ -35,7 +35,7 @@ const CalendarDetail: React.FC = () => {
         () => setCopiedStates(prev => ({ ...prev, [key]: false })),
         2000,
       );
-    });
+    }).catch((err) => console.error("Failed to copy text: ", err));
   };
   const getGlassyClasses = () => {
     return 'bg-white bg-opacity-20 rounded-lg shadow-lg'; // Customize as needed

--- a/src/components/CardDetailsPage.tsx
+++ b/src/components/CardDetailsPage.tsx
@@ -58,7 +58,7 @@ const CardDetailsPage: React.FC = () => {
         () => setCopiedStates(prev => ({ ...prev, [key]: false })),
         2000,
       );
-    });
+    }).catch((err) => console.error("Failed to copy text: ", err));
   };
 
   const CopyButton: React.FC<{ text: string; codeKey: string }> = ({

--- a/src/components/CheckboxDetails.tsx
+++ b/src/components/CheckboxDetails.tsx
@@ -43,7 +43,7 @@ const CheckboxDetailsPage: React.FC = () => {
         () => setCopiedStates(prev => ({ ...prev, [key]: false })),
         2000,
       );
-    });
+    }).catch((err) => console.error("Failed to copy text: ", err));
   };
 
   const CopyButton: React.FC<{ text: string; codeKey: string }> = ({

--- a/src/components/ContactUsDetailsPage.tsx
+++ b/src/components/ContactUsDetailsPage.tsx
@@ -23,7 +23,7 @@ const ContactUsDetailsPage: React.FC = () => {
         () => setCopiedStates(prev => ({ ...prev, [key]: false })),
         2000,
       );
-    });
+    }).catch((err) => console.error("Failed to copy text: ", err));
   };
 
   const CopyButton: React.FC<{ text: string; codeKey: string }> = ({

--- a/src/components/DropdowndetailsPage.tsx
+++ b/src/components/DropdowndetailsPage.tsx
@@ -58,7 +58,7 @@ const DropdownMenuDetailsPage: React.FC = () => {
         () => setCopiedStates(prev => ({ ...prev, [key]: false })),
         2000,
       );
-    });
+    }).catch((err) => console.error("Failed to copy text: ", err));
   };
 
   const CopyButton: React.FC<{ text: string; codeKey: string }> = ({

--- a/src/components/GalleryDetailsPage.tsx
+++ b/src/components/GalleryDetailsPage.tsx
@@ -20,7 +20,7 @@ const GalleryDetailsPage: React.FC = () => {
         () => setCopiedStates(prev => ({ ...prev, [key]: false })),
         2000,
       );
-    });
+    }).catch((err) => console.error("Failed to copy text: ", err));
   };
 
   const CopyButton: React.FC<{ text: string; codeKey: string }> = ({

--- a/src/components/GlassMorphismGenrator.tsx
+++ b/src/components/GlassMorphismGenrator.tsx
@@ -45,7 +45,7 @@ const GlassmorphismGenerator: React.FC = () => {
     navigator.clipboard.writeText(text).then(() => {
       setCopied(true);
       setTimeout(() => setCopied(false), 2000);
-    });
+    }).catch((err) => console.error("Failed to copy text: ", err));
   };
 
   const handleColorChange = (

--- a/src/components/InputDetailPage.tsx
+++ b/src/components/InputDetailPage.tsx
@@ -62,7 +62,7 @@ const InputDetailPage: React.FC = () => {
         () => setCopiedStates(prev => ({ ...prev, [key]: false })),
         2000,
       );
-    });
+    }).catch((err) => console.error("Failed to copy text: ", err));
   };
 
   // =========================

--- a/src/components/ModalDetailsPage.tsx
+++ b/src/components/ModalDetailsPage.tsx
@@ -111,7 +111,7 @@ const Modal: React.FC<ModalProps> = (props) => {
     navigator.clipboard.writeText(text).then(() => {
       setCopiedText(text);
       setTimeout(() => setCopiedText(null), 2000);
-    });
+    }).catch((err) => console.error("Failed to copy text: ", err));
   };
 
   const CopyButton: React.FC<{ text: string; codeKey: string }> = ({

--- a/src/components/NavigationDetailsPage.tsx
+++ b/src/components/NavigationDetailsPage.tsx
@@ -19,7 +19,7 @@ const NavigationDetailsPage: React.FC = () => {
     navigator.clipboard.writeText(text).then(() => {
       setCopiedText(text);
       setTimeout(() => setCopiedText(null), 2000);
-    });
+    }).catch((err) => console.error("Failed to copy text: ", err));
   };
 
   const CopyButton: React.FC<{ text: string; codeKey: string }> = ({

--- a/src/components/PaginationDetails.tsx
+++ b/src/components/PaginationDetails.tsx
@@ -21,7 +21,7 @@ const PaginationDetails: React.FC = () => {
         () => setCopiedStates(prev => ({ ...prev, [key]: false })),
         2000,
       );
-    });
+    }).catch((err) => console.error("Failed to copy text: ", err));
   };
 
   const CopyButton: React.FC<{ text: string; codeKey: string }> = ({

--- a/src/components/PopupDetailPage.tsx
+++ b/src/components/PopupDetailPage.tsx
@@ -386,7 +386,7 @@ const PopupDetailPage: React.FC = () => {
         () => setCopiedStates(prev => ({ ...prev, [key]: false })),
         2000,
       );
-    });
+    }).catch((err) => console.error("Failed to copy text: ", err));
   };
 
   return (

--- a/src/components/PricingDetailPage.tsx
+++ b/src/components/PricingDetailPage.tsx
@@ -25,7 +25,7 @@ const PricingDetailPage: React.FC = () => {
         () => setCopiedStates(prev => ({ ...prev, [key]: false })),
         2000,
       );
-    });
+    }).catch((err) => console.error("Failed to copy text: ", err));
   };
 
   const CopyButton: React.FC<{ text: string; codeKey: string }> = ({

--- a/src/components/ProductCardDetailsPage.tsx
+++ b/src/components/ProductCardDetailsPage.tsx
@@ -20,7 +20,7 @@ const ProductCardDetailsPage: React.FC = () => {
         () => setCopiedStates(prev => ({ ...prev, [key]: false })),
         2000,
       );
-    });
+    }).catch((err) => console.error("Failed to copy text: ", err));
   };
 
   const CopyButton: React.FC<{ text: string; codeKey: string }> = ({

--- a/src/components/ProgressBarDetailPage.tsx
+++ b/src/components/ProgressBarDetailPage.tsx
@@ -70,7 +70,7 @@ const ProgressBarDetailPage: React.FC = () => {
         () => setCopiedStates(prev => ({ ...prev, [key]: false })),
         2000,
       );
-    });
+    }).catch((err) => console.error("Failed to copy text: ", err));
   };
 
   const CopyButton: React.FC<{ text: string; codeKey: string }> = ({

--- a/src/components/SliderDetailsPage.tsx
+++ b/src/components/SliderDetailsPage.tsx
@@ -46,7 +46,7 @@ const SliderDetailsPage: React.FC = () => {
         () => setCopiedStates(prev => ({ ...prev, [key]: false })),
         2000,
       );
-    });
+    }).catch((err) => console.error("Failed to copy text: ", err));
   };
 
   const CopyButton: React.FC<{ text: string; codeKey: string }> = ({

--- a/src/components/SpinnerDetailsPage.tsx
+++ b/src/components/SpinnerDetailsPage.tsx
@@ -26,7 +26,7 @@ const SpinnerDetailsPage: React.FC = () => {
         () => setCopiedStates(prev => ({ ...prev, [key]: false })),
         2000,
       );
-    });
+    }).catch((err) => console.error("Failed to copy text: ", err));
   };
 
   const CopyButton: React.FC<{ text: string; codeKey: string }> = ({

--- a/src/components/StatisticDetails.tsx
+++ b/src/components/StatisticDetails.tsx
@@ -20,7 +20,7 @@ const StatisticDetails: React.FC = () => {
         () => setCopiedStates(prev => ({ ...prev, [key]: false })),
         2000,
       );
-    });
+    }).catch((err) => console.error("Failed to copy text: ", err));
   };
 
   const CopyButton: React.FC<{ text: string; codeKey: string }> = ({

--- a/src/components/StepperDetailsPage.tsx
+++ b/src/components/StepperDetailsPage.tsx
@@ -56,7 +56,7 @@ export const StepperDetailsPage: React.FC = () => {
         () => setCopiedStates(prev => ({ ...prev, [key]: false })),
         2000,
       );
-    });
+    }).catch((err) => console.error("Failed to copy text: ", err));
   };
 
   const CopyButton: React.FC<{ text: string; codeKey: string }> = ({

--- a/src/components/TestimonialDetails.tsx
+++ b/src/components/TestimonialDetails.tsx
@@ -20,7 +20,7 @@ const TestimonialDetails: React.FC = () => {
         () => setCopiedStates(prev => ({ ...prev, [key]: false })),
         2000,
       );
-    });
+    }).catch((err) => console.error("Failed to copy text: ", err));
   };
 
   const CopyButton: React.FC<{ text: string; codeKey: string }> = ({

--- a/src/components/TextareaDetailPage.tsx
+++ b/src/components/TextareaDetailPage.tsx
@@ -141,7 +141,7 @@ const TextareaDetailPage: React.FC = () => {
         () => setCopiedStates(prev => ({ ...prev, [key]: false })),
         2000,
       );
-    });
+    }).catch((err) => console.error("Failed to copy text: ", err));
   };
 
   const CopyButton: React.FC<{ text: string; codeKey: string }> = ({

--- a/src/components/TooltipDetailsPage.tsx
+++ b/src/components/TooltipDetailsPage.tsx
@@ -24,7 +24,7 @@ const TooltipDetailsPage: React.FC = () => {
         () => setCopiedStates(prev => ({ ...prev, [key]: false })),
         2000,
       );
-    });
+    }).catch((err) => console.error("Failed to copy text: ", err));
   };
 
   const CopyButton: React.FC<{ text: string; codeKey: string }> = ({

--- a/src/components/badge.tsx
+++ b/src/components/badge.tsx
@@ -79,7 +79,7 @@ const BadgeDetailPage: React.FC = () => {
     navigator.clipboard.writeText(text).then(() => {
       setCopiedStates(prev => ({ ...prev, [key]: true }));
       setTimeout(() => setCopiedStates(prev => ({ ...prev, [key]: false })), 2000);
-    });
+    }).catch((err) => console.error("Failed to copy text: ", err));
   };
 
   const CopyButton: React.FC<{ text: string, codeKey: string }> = ({ text, codeKey }) => (


### PR DESCRIPTION
Fixes #638. Added \.catch()\ error handling to \
avigator.clipboard.writeText()\ promises across multiple component detail pages to prevent unhandled promise rejection warnings in the console. Assigned under GSSoC 26.