### PR TITLE
fix: replace hardcoded localhost API URLs with env variable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,4 @@
+REACT_APP_API_BASE_URL='http://localhost:5000'
 REACT_APP_FIREBASE_API_KEY='AIzaSyBTMlmquV6yW7bMSkPk4cETVqKsUK_aEjY'
 REACT_APP_FIREBASE_AUTH_DOMAIN='gssoc-passop.firebaseapp.com'
 REACT_APP_FIREBASE_PROJECT_ID='gssoc-passop'

--- a/src/components/ContactUs.tsx
+++ b/src/components/ContactUs.tsx
@@ -27,7 +27,7 @@ const ContactUs = () => {
 
     try {
       const response = await fetch(
-        'http://localhost:5000/api/contact/saveContact',
+        `${process.env.REACT_APP_API_BASE_URL}/api/contact/saveContact`,
         {
           method: 'POST',
           headers: {

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -12,7 +12,7 @@ const Footer: React.FC = () => {
     setIsSubmitting(true);
     try {
       const response = await fetch(
-        'http://localhost:5000/api/newsletter/subscribe',
+        `${process.env.REACT_APP_API_BASE_URL}/api/newsletter/subscribe`,
         {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },

--- a/src/components/Stories.tsx
+++ b/src/components/Stories.tsx
@@ -17,7 +17,7 @@ const Stories: React.FC = () => {
     const fetchPosts = async () => {
       try {
         const response = await fetch(
-          'http://localhost:5000/api/stories/getposts',
+          `${process.env.REACT_APP_API_BASE_URL}/api/stories/getposts`,
         );
         if (response.ok) {
           const data = await response.json();
@@ -42,7 +42,7 @@ const Stories: React.FC = () => {
     };
     try {
       const response = await fetch(
-        'http://localhost:5000/api/stories/saveposts',
+        `${process.env.REACT_APP_API_BASE_URL}/api/stories/saveposts`,
         {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },


### PR DESCRIPTION
Fixes #633

Adds \REACT_APP_API_BASE_URL\ to \.env.example\ and updates \ContactUs.tsx\, \Footer.tsx\, and \Stories.tsx\ to use it instead of the hardcoded \http://localhost:5000\, allowing the deployed frontend to point to the production backend.