### PR TITLE
fix: scroll to top on pagination page change

### DIFF
--- a/src/components/GlassyUIComponentsPage.tsx
+++ b/src/components/GlassyUIComponentsPage.tsx
@@ -263,6 +263,11 @@ const GlassyUIComponentsPage: React.FC = () => {
     return () => clearTimeout(timer);
   }, [searchFilter]);
 
+  //Scroll to top on using Pagination
+  useEffect(() => {
+    window.scrollTo({ top: 70, behavior: 'smooth' });
+  }, [currentPage]);
+
   const totalPages = Math.ceil(filteredData.length / componentsPerPage);
   const currentComponents = filteredData.slice(
     (currentPage - 1) * componentsPerPage,


### PR DESCRIPTION
## Description

This PR fixes #610

Added a `useEffect` hook in `GlassyUIComponentsPage.tsx` that scrolls the page to the top whenever the `currentPage` state changes. This ensures users see the first row of components immediately after navigating to a new page via pagination, instead of having to manually scroll up.


## Notes for Reviewers
- Added a `useEffect` in `GlassyUIComponentsPage.tsx`
- It scrolls back to top on using pagination controls (`/components`)
- Smooth scroll behavior is used for a better user experience