### PR TITLE
fix: add glass backdrop fallbacks

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -149,3 +149,13 @@
 .animate-fadeIn {
   animation: fadeIn 0.2s ease-in-out;
 }
+
+@supports not (
+  (backdrop-filter: blur(1px)) or (-webkit-backdrop-filter: blur(1px))
+) {
+  .glassmorphism {
+    background: rgba(255, 255, 255, 0.78);
+    border-color: rgba(255, 255, 255, 0.42);
+    box-shadow: 0 14px 36px rgba(31, 38, 135, 0.28);
+  }
+}

--- a/src/components/FAQ.css
+++ b/src/components/FAQ.css
@@ -54,3 +54,13 @@
     font-size: 1rem;
   }
 }
+
+@supports not (
+  (backdrop-filter: blur(1px)) or (-webkit-backdrop-filter: blur(1px))
+) {
+  .faq-item {
+    background: rgba(255, 255, 255, 0.2);
+    border-color: rgba(255, 255, 255, 0.32);
+    box-shadow: 0 12px 30px rgba(15, 23, 42, 0.24);
+  }
+}

--- a/src/components/Header.css
+++ b/src/components/Header.css
@@ -294,3 +294,14 @@
     padding: 0 20px;
   }
 }
+
+@supports not (
+  (backdrop-filter: blur(1px)) or (-webkit-backdrop-filter: blur(1px))
+) {
+  .site-header--scrolled,
+  .mobile-drawer {
+    background: rgba(3, 1, 15, 0.96);
+    border-color: rgba(255, 255, 255, 0.12);
+    box-shadow: 0 12px 36px rgba(0, 0, 0, 0.38);
+  }
+}

--- a/src/index.css
+++ b/src/index.css
@@ -1734,7 +1734,6 @@ div.min-h-screen.p-8.bg-gradient-to-r.from-gray-800.via-gray-900.to-black {
 
 /* Mobile Responsiveness */
 @media screen and (max-width: 768px) {
-
   .navbar {
     flex-direction: column;
     align-items: center;
@@ -1754,7 +1753,6 @@ div.min-h-screen.p-8.bg-gradient-to-r.from-gray-800.via-gray-900.to-black {
 
 /* Small Mobile Devices */
 @media screen and (max-width: 480px) {
-
   .navbar {
     padding: 0.8rem;
   }
@@ -1768,5 +1766,29 @@ div.min-h-screen.p-8.bg-gradient-to-r.from-gray-800.via-gray-900.to-black {
     width: 100%;
     display: block;
     padding: 0.5rem 0;
+  }
+}
+
+@supports not (
+  (backdrop-filter: blur(1px)) or (-webkit-backdrop-filter: blur(1px))
+) {
+  .adaptive-glass {
+    background: rgba(15, 23, 42, 0.88);
+    border-color: rgba(255, 255, 255, 0.2);
+    box-shadow: 0 18px 48px rgba(2, 6, 23, 0.38);
+  }
+
+  .glassmorphism,
+  .frosted-glass {
+    background: rgba(255, 255, 255, 0.78);
+    border-color: rgba(255, 255, 255, 0.42);
+    box-shadow: 0 14px 36px rgba(31, 38, 135, 0.28);
+  }
+
+  .contrib-stat-card,
+  .notfound-card {
+    background: rgba(15, 23, 42, 0.82);
+    border-color: rgba(255, 255, 255, 0.16);
+    box-shadow: 0 18px 48px rgba(2, 6, 23, 0.35);
   }
 }


### PR DESCRIPTION
## Summary
- add `@supports not` fallbacks for shared glass surfaces when `backdrop-filter` / `-webkit-backdrop-filter` is unavailable
- preserve the modern blur path for supported browsers while giving older browsers readable translucent backgrounds, borders, and shadows
- cover the main app shell, reusable glassmorphism/frosted classes, header drawer surfaces, and FAQ glass cards

## Validation
- `npx prettier --check src/index.css src/App.css src/components/Header.css src/components/FAQ.css`
- `git diff --check`
- `npm run build` (passes; existing unrelated ESLint warnings remain in TSX files)

Closes #684
