### PR TITLE
fix: improve Sign Out button readability across light and dark themes

### DIFF
--- a/src/login/UserAccount.tsx
+++ b/src/login/UserAccount.tsx
@@ -22,7 +22,7 @@ const UserAccount: React.FC<UserAccountProps> = ({ email, username }) => {
         {avatarLetter}
       </div>
       <button
-        className=' text-red-500 text-sm font-medium hover:underline'
+        className='text-gray-900 dark:text-white text-sm font-medium hover:underline'
         onClick={doSignOut}
       >
         Sign Out


### PR DESCRIPTION
## Summary

Fixed the Sign Out button readability issue where the text color didn't adapt to the active theme, making it difficult to read on glass backgrounds.

## Changes
- Changed text color from fixed \	ext-red-500\ to theme-aware \	ext-gray-900 dark:text-white\
  - Light mode: dark gray text for contrast on light glass backgrounds
  - Dark mode: white text for contrast on dark glass backgrounds

Closes #614