### PR TITLE
fix: remove duplicate Toast component entry

### DIFF
--- a/src/components/GlassyUIComponentsPage.tsx
+++ b/src/components/GlassyUIComponentsPage.tsx
@@ -88,12 +88,6 @@ const GlassyUIComponentsPage: React.FC = () => {
       onClick: () => navigate('/modal-details'),
     },
     {
-      title: 'Toast',
-      description: 'Glassmorphic Toast notifications. Click to try them out!',
-      icon: <MessageSquare size={22} />,
-      onClick: () => navigate('/toast-page/'),
-    },
-    {
       title: 'Sliders',
       description: 'Elegant sliders with glassmorphic styling.',
       icon: <Sliders size={22} />,


### PR DESCRIPTION
## Description

This PR fixes a duplicate Toast component entry in the Components catalog.

### Changes Made

* Removed the duplicate **Toast** component card from `GlassyUIComponentsPage.tsx`.
* Ensured that the Toast component is displayed only once in the Components listing.

### Problem

The Components page displayed the Toast component multiple times, which could cause confusion and clutter the component catalog.

### Solution

Removed the redundant Toast entry from the `componentsData` array while keeping the original Toast component card intact.

### Testing

* Verified that the application builds successfully.
* Confirmed that only one Toast component card appears on the Components page.
* Checked that the Toast component navigation continues to work correctly.

### Related Issue

Closes #679
