### PR TITLE
fix(Tooltip): clear pending timeouts to prevent concurrent timer race conditions

### DIFF
--- a/src/components/Tooltip.tsx
+++ b/src/components/Tooltip.tsx
@@ -22,6 +22,9 @@ const Tooltip: React.FC<TooltipProps> = ({
   const timeoutRef = useRef<NodeJS.Timeout | null>(null);
 
   const showTooltip = () => {
+    if (timeoutRef.current) {
+      clearTimeout(timeoutRef.current);
+    }
     timeoutRef.current = setTimeout(() => {
       setIsVisible(true);
     }, delay);


### PR DESCRIPTION
Resolves #717

### Description of changes
- Modified `showTooltip` inside `src/components/Tooltip.tsx` to clear any existing timeout stored in `timeoutRef.current` before scheduling a new delay timeout.
- This prevents multiple timeouts from running concurrently and resolves out-of-order state updates when hover/focus events trigger rapidly.
