### PR TITLE
fix(FAQ): correct stylesheet import from SCSS to CSS

### DIFF
--- a/src/components/FAQ.tsx
+++ b/src/components/FAQ.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import './FAQ.scss';
+import './FAQ.css';
 
 const faqs = [
   {


### PR DESCRIPTION
Resolves #721

### Description of changes
- Fixed the stylesheet import in `src/components/FAQ.tsx` to import `./FAQ.css` instead of the non-existent `./FAQ.scss`.
- This resolves build and runtime bundling failures caused by the missing SCSS file.
