### PR TITLE
fix: call removeItem on auto-dismiss timer expiry in Toast component

### DIFF
--- a/src/components/Toast.tsx
+++ b/src/components/Toast.tsx
@@ -29,9 +29,10 @@ const Toast: React.FC<ToastProps> = ({
   useEffect(() => {
     const timer = setTimeout(() => {
       setHide(true);
+      setTimeout(() => removeItem(id), 400);
     }, autoDismiss);
     return () => clearTimeout(timer);
-  }, []);
+  }, [autoDismiss, id]);
 
   const getGlassyClasses = () => {
     return 'backdrop-filter backdrop-blur-md bg-white/10 border border-white/20 rounded-2xl shadow-lg transition-all duration-300';


### PR DESCRIPTION
Closes #674

The auto-dismiss timer in Toast.tsx had a split dismissal 
path. The manual dismiss button correctly runs the hide 
animation and then calls removeItem(id) after 400ms. The 
autoDismiss useEffect only set hide = true and never called 
removeItem, so auto-dismissed toasts stayed in the parent 
toasts state array forever.

What I changed:

- After setHide(true) fires in the timer, added a second 
  setTimeout that calls removeItem(id) after 400ms — same 
  timing as the manual dismiss button's animation
- Added autoDismiss and id to the effect's dependency array 
  since both are used inside it but were missing

This brings the auto-dismiss path in line with the manual 
dismiss path — both now remove the toast from state after 
the hide animation completes.

Files changed:
- src/components/Toast.tsx