### PR TITLE
fix: add email validation in Stay Updated newsletter form

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -5,10 +5,18 @@ const Footer: React.FC = () => {
   const [email, setEmail] = useState('');
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [submitted, setSubmitted] = useState(false);
+  const [emailError, setEmailError] = useState('');
 
   const handleSubmit = async (e: FormEvent) => {
     e.preventDefault();
-    if (!email) return;
+    const isValidEmail = (email: string) =>
+      /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email);
+
+    if (!isValidEmail(email)) {
+      setEmailError('Please enter a valid email address.');
+      return;
+    }
+    setEmailError('');
     setIsSubmitting(true);
     try {
       const response = await fetch(
@@ -136,18 +144,26 @@ const Footer: React.FC = () => {
           </p>
           {submitted ? (
             <div className='footer-subscribed'>
-              <span>✓</span> You're subscribed — thanks!
+              <span>✓</span> You&apos;re subscribed — thanks!
             </div>
           ) : (
             <form onSubmit={handleSubmit} className='footer-form' noValidate>
               <input
                 type='email'
                 value={email}
-                onChange={e => setEmail(e.target.value)}
+                onChange={e => {
+                  setEmail(e.target.value);
+                  setEmailError('');
+                }}
                 placeholder='your@email.com'
                 required
                 className='footer-input'
               />
+              {emailError && (
+                <p style={{ color: 'red', fontSize: '12px', marginTop: '4px' }}>
+                  {emailError}
+                </p>
+              )}
               <button
                 type='submit'
                 disabled={isSubmitting}


### PR DESCRIPTION
## Description

This PR fixes #631 

Added email validation to the **Stay Updated** newsletter form in `Footer.tsx`. Previously, the form accepted any input (plain text, numbers, special characters) without any validation. Now users must enter a properly formatted email address before subscribing.

## Notes for Reviewers

- Added `isValidEmail` regex validation function in the `handleSubmit` handler in `Footer.tsx`
- Added `emailError` state to store and display the validation error message
- Error message renders inline when invalid email is entered
- Error clears automatically as the user starts typing again
- Used `noValidate` on the form to disable browser's default validation popup and rely on custom error message instead
- Also fixed a pre-existing`react/no-unescaped-entities` error on line 147 (`You're` → `You&apos;re`)
